### PR TITLE
fix: Add missing repository and author to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,10 @@
     "semantic-search"
   ],
   "license": "MIT",
+  "author": "MemoClaw",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anajuliabit/memoclaw-mcp"
+  },
   "mcpName": "io.github.anajuliabit/memoclaw-mcp"
 }


### PR DESCRIPTION
package.json was missing `repository` and `author` fields.