### PR TITLE
fix: add files and engines fields for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,12 @@
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "keywords": [
     "mcp",
     "memory",


### PR DESCRIPTION
Without a `files` field, `npm publish` would include the entire repo (src/, tests, etc). Also adds `engines` to require Node 18+.