### PR TITLE
feat: add memoclaw_delete_relation tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['memory_id'],
       },
     },
+    {
+      name: 'memoclaw_delete_relation',
+      description: 'Delete a relationship between two memories.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          memory_id: { type: 'string', description: 'Source memory ID' },
+          relation_id: { type: 'string', description: 'Relation ID to delete' },
+        },
+        required: ['memory_id', 'relation_id'],
+      },
+    },
   ],
 }));
 
@@ -388,6 +400,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'memoclaw_list_relations': {
         const { memory_id } = args as any;
         const result = await makeRequest('GET', `/v1/memories/${memory_id}/relations`);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case 'memoclaw_delete_relation': {
+        const { memory_id, relation_id } = args as any;
+        const result = await makeRequest('DELETE', `/v1/memories/${memory_id}/relations/${relation_id}`);
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
       }
 


### PR DESCRIPTION
The API and Python SDK support deleting relations but the MCP server was missing this tool.