### PR TITLE
fix: MCP protocol improvements — version, tags, params, error handling, tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoclaw-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -21,6 +21,9 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -92,9 +92,10 @@ describe('MCP Server Tool Definitions', () => {
     expect(toolNames).toContain('memoclaw_update');
     expect(toolNames).toContain('memoclaw_create_relation');
     expect(toolNames).toContain('memoclaw_list_relations');
+    expect(toolNames).toContain('memoclaw_delete_relation');
   });
 
-  it('should have 12 tools total', async () => {
+  it('should have 13 tools total', async () => {
     const result = await listToolsHandler();
     expect(result.tools).toHaveLength(13);
   });


### PR DESCRIPTION
## Changes

- **Version mismatch**: Server constructor reported 1.2.0 while package.json is 1.3.0
- **Store tags bug**: `tags` were incorrectly nested under `metadata.tags` instead of sent as top-level `tags` field
- **Falsy-zero bug**: `limit=0` and `offset=0` were silently dropped in `memoclaw_list` and `memoclaw_suggested` due to truthy checks
- **Recall data loss**: Formatted response discarded memory IDs and full metadata needed for follow-up operations (update/delete/relate). Now includes both summary and raw JSON
- **Status inconsistent error handling**: `memoclaw_status` bypassed `makeRequest`, missing wallet auth retry on 402 and consistent error formatting. Now uses `makeRequest`
- **Unnecessary Content-Type on GET**: GET requests sent `Content-Type: application/json` header with no body
- **Test description mismatch**: Said "should have 12 tools" but asserted 13
- **Missing test coverage**: `memoclaw_delete_relation` was not checked in tool list test