### PR TITLE
security: add .env to gitignore, fix qs vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+.env
+.env.*
+!.env.example

--- a/package-lock.json
+++ b/package-lock.json
@@ -2208,9 +2208,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Security Audit Fixes

- **MEDIUM**: Add `.env` to `.gitignore` — prevents accidental commit of `MEMOCLAW_PRIVATE_KEY`
- **LOW**: Fix qs DoS vulnerability (GHSA-w7fw-mjwx-w883) via npm audit fix

### Audit findings (no code change needed)
- No hardcoded secrets in code ✅
- Private key properly read from env var with fail-fast ✅
- No path traversal or injection vectors in MCP tool handlers ✅
