### PR TITLE
fix: prevent delete_namespace infinite loop on failed deletes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -998,6 +998,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 // Paginate through all memories in namespace and delete them
                 const deletedIds = [];
                 const errors = [];
+                const failedIds = new Set();
                 let pages = 0;
                 const pageSize = 100;
                 const maxPages = 200; // Safety valve: 200 pages × 100 = 20k max
@@ -1005,9 +1006,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     pages++;
                     const params = new URLSearchParams();
                     params.set('limit', String(pageSize));
-                    // Always fetch offset 0: successful deletes shrink the list.
-                    // If ALL deletes on a page fail, we advance offset to skip them.
-                    params.set('offset', String(errors.length));
+                    // Offset past memories we already tried and failed to delete
+                    params.set('offset', String(failedIds.size));
                     params.set('namespace', namespace);
                     if (agent_id)
                         params.set('agent_id', agent_id);
@@ -1015,15 +1015,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     const memories = result.memories || result.data || [];
                     if (memories.length === 0)
                         break;
-                    const deleteResults = await withConcurrency(memories.map((m) => () => makeRequest('DELETE', `/v1/memories/${m.id}`)), 10);
+                    // Filter out memories we already failed to delete (in case offset doesn't skip them exactly)
+                    const toDelete = memories.filter((m) => !failedIds.has(m.id));
+                    if (toDelete.length === 0)
+                        break;
+                    const deleteResults = await withConcurrency(toDelete.map((m) => () => makeRequest('DELETE', `/v1/memories/${m.id}`)), 10);
                     let pageSuccesses = 0;
                     for (let i = 0; i < deleteResults.length; i++) {
                         if (deleteResults[i].status === 'fulfilled') {
-                            deletedIds.push(memories[i].id);
+                            deletedIds.push(toDelete[i].id);
                             pageSuccesses++;
                         }
                         else {
-                            errors.push(`${memories[i].id}: ${deleteResults[i].reason?.message || 'unknown'}`);
+                            failedIds.add(toDelete[i].id);
+                            errors.push(`${toDelete[i].id}: ${deleteResults[i].reason?.message || 'unknown'}`);
                         }
                     }
                     // If we got fewer than pageSize, we're done


### PR DESCRIPTION
## Problem
`memoclaw_delete_namespace` could enter an infinite loop when some deletes fail. The offset was based on `errors.length` which could desync from actual list positions, causing the same page to be re-fetched repeatedly until the 200-page safety valve.

## Fix
- Track failed memory IDs in a `Set` instead of using `errors.length` as offset proxy
- Use `failedIds.size` as offset (exact count of undeletable memories to skip)
- Filter out already-failed IDs from each batch to avoid retrying them

Fixes MEM-19