### PR TITLE
feat: add memoclaw_pin and memoclaw_unpin tools

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -162,7 +162,7 @@ const UPDATE_FIELDS = new Set([
     'content', 'importance', 'memory_type', 'namespace',
     'metadata', 'expires_at', 'pinned', 'tags',
 ]);
-const server = new Server({ name: 'memoclaw', version: '1.8.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'memoclaw', version: '1.9.0' }, { capabilities: { tools: {} } });
 // ─── Tool Definitions ────────────────────────────────────────────────────────
 const TOOLS = [
     {
@@ -581,6 +581,32 @@ const TOOLS = [
                 relation_type: { type: 'string', enum: ['related_to', 'derived_from', 'contradicts', 'supersedes', 'supports'], description: 'Only follow relations of this type. Default: all types.' },
             },
             required: ['memory_id'],
+        },
+    },
+    {
+        name: 'memoclaw_pin',
+        description: '📌 Pin a memory to prevent it from decaying over time. ' +
+            'Pinned memories persist indefinitely and are never auto-deleted by decay. ' +
+            'Shortcut for memoclaw_update with pinned=true.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string', description: 'The memory ID to pin.' },
+            },
+            required: ['id'],
+        },
+    },
+    {
+        name: 'memoclaw_unpin',
+        description: '📌 Unpin a memory, re-enabling normal decay behavior. ' +
+            'After unpinning, the memory will decay according to its memory_type. ' +
+            'Shortcut for memoclaw_update with pinned=false.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string', description: 'The memory ID to unpin.' },
+            },
+            required: ['id'],
         },
     },
     {
@@ -1271,6 +1297,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     }
                     throw err;
                 }
+            }
+            case 'memoclaw_pin': {
+                const { id } = args;
+                if (!id)
+                    throw new Error('id is required');
+                const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
+                return { content: [{ type: 'text', text: `📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}` }] };
+            }
+            case 'memoclaw_unpin': {
+                const { id } = args;
+                if (!id)
+                    throw new Error('id is required');
+                const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
+                return { content: [{ type: 'text', text: `📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}` }] };
             }
             case 'memoclaw_namespaces': {
                 const { agent_id } = args;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "MCP server for MemoClaw semantic memory API. 1000 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Adds dedicated `memoclaw_pin` and `memoclaw_unpin` convenience tools for pinning/unpinning memories.

Pinned memories are exempt from decay and persist indefinitely.

- `memoclaw_pin`: pin a memory by ID (PATCH pinned=true)
- `memoclaw_unpin`: unpin a memory by ID (PATCH pinned=false)

Previously, pinning required using `memoclaw_update` with `pinned: true/false`. These dedicated tools make the intent clearer and are more discoverable.

## Changes
- Added 2 new tool definitions and handlers in `src/index.ts`
- Added 4 tests (validation + correct API calls)
- Updated tool count test
- Bumped version to 1.9.0

Closes MEM-52