### PR TITLE
feat: add memoclaw_tags tool to list unique tags with counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "MCP server for MemoClaw semantic memory API. 1000 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Adds `memoclaw_tags` tool that lists all unique tags across memories with counts, sorted by usage (most used first). Similar to `memoclaw_namespaces`.

Supports `namespace` and `agent_id` filters. Reads tags from both `tags` field and `metadata.tags` fallback.

- 28 tools total
- 109 tests passing (4 new tests)
- Version bumped to 1.10.0

Closes MEM-76