### PR TITLE
feat: add memoclaw_context tool

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -162,7 +162,7 @@ const UPDATE_FIELDS = new Set([
     'content', 'importance', 'memory_type', 'namespace',
     'metadata', 'expires_at', 'pinned', 'tags',
 ]);
-const server = new Server({ name: 'memoclaw', version: '1.11.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'memoclaw', version: '1.12.0' }, { capabilities: { tools: {} } });
 // ─── Tool Definitions ────────────────────────────────────────────────────────
 const TOOLS = [
     {
@@ -645,6 +645,28 @@ const TOOLS = [
             properties: {
                 agent_id: { type: 'string', description: 'Only list namespaces for this agent.' },
             },
+        },
+    },
+    {
+        name: 'memoclaw_context',
+        description: '🧠 CONTEXT: Get contextually relevant memories for your current situation. ' +
+            'Unlike memoclaw_recall (single query), this uses GPT-4o-mini to analyze your prompt and ' +
+            'intelligently select the most relevant memories across multiple dimensions (semantic similarity, ' +
+            'recency, importance, relations). ' +
+            'Use this when you need a curated set of memories for a complex task — e.g. "prepare for a meeting with Bob" ' +
+            'or "what do I know about the frontend migration?". ' +
+            'Returns a ranked list of memories with relevance explanations. ' +
+            'Costs $0.01 per call (uses GPT-4o-mini + embeddings).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'Describe your current situation or what you need context for. Be descriptive — e.g. "preparing a code review for the auth module" rather than just "auth".' },
+                limit: { type: 'number', description: 'Maximum number of memories to return. Default: 10. Max: 50.' },
+                namespace: { type: 'string', description: 'Only include memories from this namespace.' },
+                session_id: { type: 'string', description: 'Prioritize memories from this session.' },
+                agent_id: { type: 'string', description: 'Only include memories from this agent.' },
+            },
+            required: ['query'],
         },
     },
 ];
@@ -1404,6 +1426,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     return parts.join('\n');
                 }).join('\n\n');
                 return { content: [{ type: 'text', text: `📜 History for memory ${id} (${history.length} versions):\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+            }
+            case 'memoclaw_context': {
+                const { query, limit, namespace, session_id, agent_id } = args;
+                if (!query || (typeof query === 'string' && query.trim() === '')) {
+                    throw new Error('query is required and cannot be empty');
+                }
+                const body = { query };
+                if (limit !== undefined)
+                    body.limit = limit;
+                if (namespace)
+                    body.namespace = namespace;
+                if (session_id)
+                    body.session_id = session_id;
+                if (agent_id)
+                    body.agent_id = agent_id;
+                const result = await makeRequest('POST', '/v1/context', body);
+                const memories = result.memories || result.context || [];
+                if (memories.length === 0) {
+                    return { content: [{ type: 'text', text: `No relevant context found for: "${query}"` }] };
+                }
+                const formatted = memories.map((m) => formatMemory(m)).join('\n\n');
+                return { content: [{ type: 'text', text: `🧠 Context for "${query}" (${memories.length} memories):\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
             }
             case 'memoclaw_namespaces': {
                 const { agent_id } = args;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "MCP server for MemoClaw semantic memory API. 1000 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Adds `memoclaw_context` tool that calls `POST /v1/context` to get contextually relevant memories using GPT-4o-mini analysis.

Unlike `memoclaw_recall` (single semantic query), context intelligently selects memories across multiple dimensions (similarity, recency, importance, relations) for complex situations like "prepare for a meeting with Bob".

## Changes
- Add `memoclaw_context` tool definition with query/limit/namespace/session_id/agent_id params
- Add handler calling `POST /v1/context` with formatted output
- Add 8 tests (1 definition + 7 handler tests)
- Bump version 1.11.0 → 1.12.0 (29 → 30 tools)

## Pricing
$0.01 per call (uses GPT-4o-mini + embeddings), consistent with product context.

Closes MEM-90