### PR TITLE
docs: update README with all 33 tools and correct pricing (MEM-100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm](https://img.shields.io/npm/v/memoclaw-mcp)](https://www.npmjs.com/package/memoclaw-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-MCP (Model Context Protocol) server for MemoClaw semantic memory API.
+MCP (Model Context Protocol) server for [MemoClaw](https://memoclaw.com) — semantic memory for AI agents. Store, recall, and manage memories with vector search. 1000 free API calls per wallet, no registration needed.
 
 ## Installation
 
@@ -14,9 +14,19 @@ npm install -g memoclaw-mcp
 
 ## Configuration
 
-Set your private key:
+Set your private key via environment variable or config file:
+
 ```bash
+# Option 1: env var
 export MEMOCLAW_PRIVATE_KEY=0x...
+
+# Option 2: config file (created by `memoclaw init`)
+# ~/.memoclaw/config.json → { "privateKey": "0x...", "url": "https://api.memoclaw.com" }
+```
+
+Optionally set a custom API URL:
+```bash
+export MEMOCLAW_URL=https://api.memoclaw.com  # default
 ```
 
 ### Claude Desktop
@@ -42,52 +52,112 @@ Add to MCP settings in Cursor preferences.
 
 ## Tools
 
+### Core
+
 | Tool | Description |
 |------|-------------|
 | `memoclaw_store` | Store a memory with semantic embeddings |
-| `memoclaw_recall` | Recall memories via semantic search |
-| `memoclaw_list` | List stored memories |
+| `memoclaw_recall` | Semantic search — find memories by meaning |
+| `memoclaw_search` | Keyword search — find memories by exact text |
+| `memoclaw_get` | Get a single memory by ID |
+| `memoclaw_list` | List memories chronologically |
 | `memoclaw_delete` | Delete a memory by ID |
-| `memoclaw_status` | Check free tier remaining calls |
-| `memoclaw_ingest` | Zero-effort ingestion: dump conversations/text, auto-extract facts with dedup & relations |
+| `memoclaw_update` | Update a memory's fields |
+| `memoclaw_context` | Get contextually relevant memories using GPT-4o-mini |
+
+### Bulk operations
+
+| Tool | Description |
+|------|-------------|
+| `memoclaw_bulk_store` | Store up to 50 memories in one call |
+| `memoclaw_bulk_delete` | Delete up to 100 memories in one call |
+| `memoclaw_batch_update` | Update up to 50 memories in one call |
+| `memoclaw_import` | Import memories from a JSON array |
+| `memoclaw_export` | Export all memories as JSON or JSONL |
+
+### Ingestion and extraction
+
+| Tool | Description |
+|------|-------------|
+| `memoclaw_ingest` | Dump conversations/text, auto-extract facts with dedup and relations |
 | `memoclaw_extract` | Extract structured facts from conversation via LLM |
-| `memoclaw_consolidate` | Merge similar memories by clustering |
-| `memoclaw_suggested` | Get proactive memory suggestions |
-| `memoclaw_update` | Update a memory by ID |
-| `memoclaw_create_relation` | Create a relationship between memories |
-| `memoclaw_list_relations` | List all relationships for a memory |
+| `memoclaw_consolidate` | Merge similar/duplicate memories by clustering |
+| `memoclaw_migrate` | Bulk-import .md/.txt files into MemoClaw |
 
-## Example Usage
+### Organization
 
-Once configured, Claude can use commands like:
+| Tool | Description |
+|------|-------------|
+| `memoclaw_pin` | Pin a memory to prevent decay |
+| `memoclaw_unpin` | Unpin a memory |
+| `memoclaw_tags` | List all unique tags with counts |
+| `memoclaw_namespaces` | List all namespaces with counts |
+| `memoclaw_count` | Count memories (with optional filters) |
+| `memoclaw_delete_namespace` | Delete all memories in a namespace |
+
+### Knowledge graph
+
+| Tool | Description |
+|------|-------------|
+| `memoclaw_create_relation` | Create a relationship between two memories |
+| `memoclaw_list_relations` | List relationships for a memory |
+| `memoclaw_delete_relation` | Delete a relationship |
+| `memoclaw_graph` | Traverse the memory graph from a starting memory |
+
+### Insights and status
+
+| Tool | Description |
+|------|-------------|
+| `memoclaw_suggested` | Get proactive suggestions (stale, fresh, hot, decaying) |
+| `memoclaw_core_memories` | Get your most important/frequently accessed memories |
+| `memoclaw_stats` | Memory usage statistics |
+| `memoclaw_history` | View edit history for a memory |
+| `memoclaw_status` | Check free tier remaining calls |
+| `memoclaw_init` | Verify configuration and API connectivity |
+
+## Example usage
+
+Once configured, your AI agent can:
 
 - "Remember that the meeting is at 3pm tomorrow"
 - "What did I say about the project deadline?"
-- "List my recent memories"
+- "Show me my core memories"
+- "Consolidate duplicate memories (dry run first)"
 
 ## Pricing
 
-**Free Tier:** Every wallet gets **1000 free API calls** — no payment required.
+Every wallet gets **1000 free API calls** — no payment required.
 
-After the free tier:
-- Store: $0.001 per memory
-- Recall: $0.001 per query
-- List: $0.0005
-- Update: $0.001
-- Delete: $0.0001
-- Ingest: $0.005
-- Extract: $0.005
-- Consolidate: $0.005
-- Suggested: $0.001
-- Relations: $0.0005
+After the free tier, x402 micropayments kick in automatically:
 
-Paid with USDC on Base via x402 protocol. The server handles payment automatically.
+**Paid (uses embeddings):**
+
+| Operation | Price |
+|-----------|-------|
+| Store | $0.005 |
+| Store batch (up to 100) | $0.04 |
+| Recall (semantic search) | $0.005 |
+| Update (content change) | $0.005 |
+| Batch update | $0.005 |
+
+**Paid (uses GPT-4o-mini + embeddings):**
+
+| Operation | Price |
+|-----------|-------|
+| Extract / Ingest | $0.01 |
+| Consolidate | $0.01 |
+| Context | $0.01 |
+| Migrate | $0.01 |
+
+**Free (no OpenAI cost):**
+List, Get, Delete, Bulk Delete, Search (text), Suggested, Core memories, Relations, History, Export, Namespaces, Stats, Tags, Pin/Unpin, Count, Status, Init.
 
 ## Links
 
-- [MemoClaw Website](https://memoclaw.com)
-- [MemoClaw Docs](https://docs.memoclaw.com)
-- [MCP Specification](https://modelcontextprotocol.io)
+- Website: https://memoclaw.com
+- Docs: https://docs.memoclaw.com
+- API: https://api.memoclaw.com
+- CLI: `npm install -g memoclaw`
 
 ## License
 


### PR DESCRIPTION
The README only listed 13 tools — we actually have 33. Pricing was also wrong.

Changes:
- Added all missing tools organized into sections (core, bulk ops, ingestion, organization, knowledge graph, insights)
- Fixed pricing to match actual API costs from PRODUCT_CONTEXT
- Added config file documentation
- Listed which endpoints are free vs paid

Closes MEM-100