### PR TITLE
fix: update free tier references from 1000 to 100 calls (MEM-111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Once configured, your AI agent can:
 
 ## Pricing
 
-Every wallet gets **1000 free API calls** — no payment required.
+**Free Tier:** Every wallet gets **100 free API calls** — no payment required.
 
 After the free tier, x402 micropayments kick in automatically:
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -170,7 +170,7 @@ const TOOLS = [
         description: 'Store a new memory. The content is embedded for semantic search. ' +
             'Use tags and namespace to organize memories. Set importance (0-1) to influence recall ranking. ' +
             'Use memory_type to control how the memory decays over time. Pin important memories to prevent decay. ' +
-            'Returns the created memory object with its ID. Free tier: 1000 calls/wallet.',
+            'Returns the created memory object with its ID. Free tier: 100 calls/wallet.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -314,7 +314,7 @@ const TOOLS = [
     },
     {
         name: 'memoclaw_status',
-        description: 'Check your wallet\'s free tier usage. Shows remaining API calls out of the 1000 free calls per wallet. ' +
+        description: 'Check your wallet\'s free tier usage. Shows remaining API calls out of the 100 free calls per wallet. ' +
             'Call this to know if you\'re about to hit the limit before paid (x402) kicks in.',
         inputSchema: {
             type: 'object',
@@ -882,7 +882,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             case 'memoclaw_status': {
                 const data = await makeRequest('GET', '/v1/free-tier/status');
                 const remaining = data.free_tier_remaining ?? 'unknown';
-                const total = data.free_tier_total ?? 1000;
+                const total = data.free_tier_total ?? 100;
                 const pct = typeof remaining === 'number' ? Math.round((remaining / total) * 100) : '?';
                 return {
                     content: [{
@@ -1288,7 +1288,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 try {
                     const data = await makeRequest('GET', '/v1/free-tier/status');
                     const remaining = data.free_tier_remaining ?? 'unknown';
-                    const total = data.free_tier_total ?? 1000;
+                    const total = data.free_tier_total ?? 100;
                     checks.push(`✅ API reachable`);
                     checks.push(`📊 Free tier: ${remaining}/${total} calls remaining`);
                     if (typeof remaining === 'number' && remaining <= 0) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memoclaw-mcp",
   "version": "1.13.0",
-  "description": "MCP server for MemoClaw semantic memory API. 1000 free calls per wallet.",
+  "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ const TOOLS = [
       'Store a new memory. The content is embedded for semantic search. ' +
       'Use tags and namespace to organize memories. Set importance (0-1) to influence recall ranking. ' +
       'Use memory_type to control how the memory decays over time. Pin important memories to prevent decay. ' +
-      'Returns the created memory object with its ID. Free tier: 1000 calls/wallet.',
+      'Returns the created memory object with its ID. Free tier: 100 calls/wallet.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -346,7 +346,7 @@ const TOOLS = [
   {
     name: 'memoclaw_status',
     description:
-      'Check your wallet\'s free tier usage. Shows remaining API calls out of the 1000 free calls per wallet. ' +
+      'Check your wallet\'s free tier usage. Shows remaining API calls out of the 100 free calls per wallet. ' +
       'Call this to know if you\'re about to hit the limit before paid (x402) kicks in.',
     inputSchema: {
       type: 'object' as const,
@@ -926,7 +926,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'memoclaw_status': {
         const data = await makeRequest('GET', '/v1/free-tier/status');
         const remaining = data.free_tier_remaining ?? 'unknown';
-        const total = data.free_tier_total ?? 1000;
+        const total = data.free_tier_total ?? 100;
         const pct = typeof remaining === 'number' ? Math.round((remaining / total) * 100) : '?';
         return {
           content: [{
@@ -1328,7 +1328,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         try {
           const data = await makeRequest('GET', '/v1/free-tier/status');
           const remaining = data.free_tier_remaining ?? 'unknown';
-          const total = data.free_tier_total ?? 1000;
+          const total = data.free_tier_total ?? 100;
           checks.push(`✅ API reachable`);
           checks.push(`📊 Free tier: ${remaining}/${total} calls remaining`);
           if (typeof remaining === 'number' && remaining <= 0) {


### PR DESCRIPTION
Free tier was intentionally reduced from 1000 to 100 calls per wallet on Feb 15, 2026. This PR updates all stale references in package.json, README.md, and src/index.ts.

Closes MEM-111