### PR TITLE
perf: optimize memoclaw_tags and memoclaw_namespaces with server-side endpoints (MEM-115)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -613,7 +613,8 @@ const TOOLS = [
         name: 'memoclaw_tags',
         description: '🏷️ List all unique tags across your memories with counts. ' +
             'Use this to discover what tags exist before filtering recall/list/search by tags. ' +
-            'Returns tags sorted by usage count (most used first).',
+            'Returns tags sorted by usage count (most used first). ' +
+            '⚠️ May be slow for wallets with many memories (falls back to client-side pagination if /v1/tags is unavailable).',
         inputSchema: {
             type: 'object',
             properties: {
@@ -639,7 +640,8 @@ const TOOLS = [
         name: 'memoclaw_namespaces',
         description: 'List all namespaces that contain memories. Returns an array of namespace names with memory counts. ' +
             'Use this to discover what namespaces exist before filtering recall/list/search by namespace. ' +
-            'Memories without a namespace appear under "(default)".',
+            'Memories without a namespace appear under "(default)". ' +
+            '⚠️ May be slow for wallets with many memories (falls back to client-side pagination if /v1/namespaces is unavailable).',
         inputSchema: {
             type: 'object',
             properties: {
@@ -1419,6 +1421,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
             case 'memoclaw_tags': {
                 const { namespace, agent_id } = args;
+                // Try dedicated /v1/tags endpoint first (fast, server-side aggregation)
+                try {
+                    const params = new URLSearchParams();
+                    if (namespace)
+                        params.set('namespace', namespace);
+                    if (agent_id)
+                        params.set('agent_id', agent_id);
+                    const qs = params.toString();
+                    const result = await makeRequest('GET', `/v1/tags${qs ? '?' + qs : ''}`);
+                    if (result.tags) {
+                        const tags = result.tags;
+                        if (tags.length === 0) {
+                            return { content: [{ type: 'text', text: 'No tags found across memories.' }] };
+                        }
+                        const lines = tags.map((t) => typeof t === 'string' ? `  • ${t}` : `  • ${t.tag || t.name}: ${t.count} memories`);
+                        return { content: [{ type: 'text', text: `🏷️ ${tags.length} tags:\n\n${lines.join('\n')}` }] };
+                    }
+                }
+                catch {
+                    // Endpoint not available — fall back to client-side aggregation
+                }
                 const tagCounts = new Map();
                 let offset = 0;
                 const pageSize = 100;
@@ -1508,6 +1531,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
             case 'memoclaw_namespaces': {
                 const { agent_id } = args;
+                // Try dedicated /v1/namespaces endpoint first (fast, server-side aggregation)
+                try {
+                    const params = new URLSearchParams();
+                    if (agent_id)
+                        params.set('agent_id', agent_id);
+                    const qs = params.toString();
+                    const result = await makeRequest('GET', `/v1/namespaces${qs ? '?' + qs : ''}`);
+                    if (result.namespaces) {
+                        const namespaces = result.namespaces;
+                        if (namespaces.length === 0) {
+                            return { content: [{ type: 'text', text: 'No memories found — no namespaces to list.' }] };
+                        }
+                        const lines = namespaces.map((n) => typeof n === 'string' ? `  • ${n}` : `  • ${n.namespace || n.name || '(default)'}: ${n.count} memories`);
+                        return { content: [{ type: 'text', text: `📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}` }] };
+                    }
+                }
+                catch {
+                    // Endpoint not available — fall back to client-side aggregation
+                }
                 const nsCounts = new Map();
                 let offset = 0;
                 const pageSize = 100;

--- a/src/index.ts
+++ b/src/index.ts
@@ -662,7 +662,8 @@ const TOOLS = [
     description:
       '🏷️ List all unique tags across your memories with counts. ' +
       'Use this to discover what tags exist before filtering recall/list/search by tags. ' +
-      'Returns tags sorted by usage count (most used first).',
+      'Returns tags sorted by usage count (most used first). ' +
+      '⚠️ May be slow for wallets with many memories (falls back to client-side pagination if /v1/tags is unavailable).',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -690,7 +691,8 @@ const TOOLS = [
     description:
       'List all namespaces that contain memories. Returns an array of namespace names with memory counts. ' +
       'Use this to discover what namespaces exist before filtering recall/list/search by namespace. ' +
-      'Memories without a namespace appear under "(default)".',
+      'Memories without a namespace appear under "(default)". ' +
+      '⚠️ May be slow for wallets with many memories (falls back to client-side pagination if /v1/namespaces is unavailable).',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -1461,6 +1463,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'memoclaw_tags': {
         const { namespace, agent_id } = args as any;
+
+        // Try dedicated /v1/tags endpoint first (fast, server-side aggregation)
+        try {
+          const params = new URLSearchParams();
+          if (namespace) params.set('namespace', namespace);
+          if (agent_id) params.set('agent_id', agent_id);
+          const qs = params.toString();
+          const result = await makeRequest('GET', `/v1/tags${qs ? '?' + qs : ''}`);
+          if (result.tags) {
+            const tags = result.tags;
+            if (tags.length === 0) {
+              return { content: [{ type: 'text', text: 'No tags found across memories.' }] };
+            }
+            const lines = tags.map((t: any) =>
+              typeof t === 'string' ? `  • ${t}` : `  • ${t.tag || t.name}: ${t.count} memories`
+            );
+            return { content: [{ type: 'text', text: `🏷️ ${tags.length} tags:\n\n${lines.join('\n')}` }] };
+          }
+        } catch {
+          // Endpoint not available — fall back to client-side aggregation
+        }
+
         const tagCounts = new Map<string, number>();
         let offset = 0;
         const pageSize = 100;
@@ -1543,6 +1567,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'memoclaw_namespaces': {
         const { agent_id } = args as any;
+
+        // Try dedicated /v1/namespaces endpoint first (fast, server-side aggregation)
+        try {
+          const params = new URLSearchParams();
+          if (agent_id) params.set('agent_id', agent_id);
+          const qs = params.toString();
+          const result = await makeRequest('GET', `/v1/namespaces${qs ? '?' + qs : ''}`);
+          if (result.namespaces) {
+            const namespaces = result.namespaces;
+            if (namespaces.length === 0) {
+              return { content: [{ type: 'text', text: 'No memories found — no namespaces to list.' }] };
+            }
+            const lines = namespaces.map((n: any) =>
+              typeof n === 'string' ? `  • ${n}` : `  • ${n.namespace || n.name || '(default)'}: ${n.count} memories`
+            );
+            return { content: [{ type: 'text', text: `📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}` }] };
+          }
+        } catch {
+          // Endpoint not available — fall back to client-side aggregation
+        }
+
         const nsCounts = new Map<string, number>();
         let offset = 0;
         const pageSize = 100;


### PR DESCRIPTION
Closes MEM-115

**Problem:** Both `memoclaw_tags` and `memoclaw_namespaces` paginated through ALL memories (up to 20k) client-side to compute tag/namespace counts. Extremely slow and expensive for users with many memories.

**Solution:**
1. Try dedicated server-side endpoints first (`/v1/tags`, `/v1/namespaces`)
2. Fall back to client-side pagination only if endpoints are unavailable or don't return the expected response format
3. Added performance warnings in tool descriptions

**Tests:** 3 new tests (dedicated endpoint paths + fallback), 136 total all passing