### PR TITLE
feat: Add Streamable HTTP transport (MCP spec 2025-03-26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm](https://img.shields.io/npm/v/memoclaw-mcp)](https://www.npmjs.com/package/memoclaw-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-MCP (Model Context Protocol) server for [MemoClaw](https://memoclaw.com) — semantic memory for AI agents. Store, recall, and manage memories with vector search. 1000 free API calls per wallet, no registration needed.
+MCP (Model Context Protocol) server for [MemoClaw](https://memoclaw.com) — semantic memory for AI agents. Store, recall, and manage memories with vector search. 100 free API calls per wallet, no registration needed.
 
 ## Installation
 
@@ -49,6 +49,27 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ### Cursor
 
 Add to MCP settings in Cursor preferences.
+
+### Streamable HTTP Transport
+
+By default, the server uses stdio transport. To run as an HTTP server (MCP spec 2025-03-26 Streamable HTTP):
+
+```bash
+# Via CLI flag
+memoclaw-mcp --http
+
+# Via environment variable
+MEMOCLAW_TRANSPORT=http memoclaw-mcp
+
+# Custom port (default: 3100)
+MEMOCLAW_PORT=8080 memoclaw-mcp --http
+```
+
+The server exposes:
+- `POST /mcp` — MCP Streamable HTTP endpoint
+- `GET /health` — Health check returning `{ status: "ok", version: "..." }`
+
+Configure your MCP client to connect to `http://localhost:3100/mcp`.
 
 ## Tools
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -8,6 +9,7 @@ import {
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
 
 import { loadConfig } from './config.js';
 import { createApiClient } from './api.js';
@@ -16,7 +18,7 @@ import { createHandler } from './handlers.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let VERSION = '1.13.0';
+let VERSION = '1.14.0';
 try {
   const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
   VERSION = pkg.version;
@@ -50,11 +52,67 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
+/**
+ * Determine transport mode from CLI args and env vars.
+ * --http or MEMOCLAW_TRANSPORT=http → Streamable HTTP
+ * Otherwise → stdio (default, backward-compatible)
+ */
+function getTransportMode(): 'stdio' | 'http' {
+  if (process.argv.includes('--http')) return 'http';
+  if (process.env.MEMOCLAW_TRANSPORT?.toLowerCase() === 'http') return 'http';
+  return 'stdio';
+}
+
+/** Default port for HTTP transport */
+function getHttpPort(): number {
+  const envPort = process.env.MEMOCLAW_PORT || process.env.PORT;
+  if (envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed < 65536) return parsed;
+  }
+  return 3100;
+}
+
 // Start server
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('MemoClaw MCP server running (free tier enabled)');
+  const mode = getTransportMode();
+
+  if (mode === 'http') {
+    const port = getHttpPort();
+
+    const httpServer = createServer(async (req, res) => {
+      const url = new URL(req.url || '/', `http://localhost:${port}`);
+
+      // Health check endpoint
+      if (url.pathname === '/health' && req.method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', version: VERSION }));
+        return;
+      }
+
+      // MCP endpoint
+      if (url.pathname === '/mcp') {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      // 404 for everything else
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found. Use /mcp for MCP protocol or /health for status.' }));
+    });
+
+    httpServer.listen(port, () => {
+      console.error(`MemoClaw MCP server running on http://localhost:${port}/mcp (Streamable HTTP)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('MemoClaw MCP server running (free tier enabled)');
+  }
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary

Adds support for the Streamable HTTP transport from the MCP spec (2025-03-26), allowing memoclaw-mcp to run as an HTTP server in addition to the default stdio mode.

## Usage

```bash
# CLI flag
memoclaw-mcp --http

# Environment variable
MEMOCLAW_TRANSPORT=http memoclaw-mcp

# Custom port (default: 3100)
MEMOCLAW_PORT=8080 memoclaw-mcp --http
```

## Endpoints

- `POST /mcp` — MCP Streamable HTTP endpoint
- `GET /health` — Health check

## Why

Streamable HTTP enables remote MCP server deployments, containerized setups, and multi-client connections — useful for hosted agents and team environments.

Closes MEM-156