### PR TITLE
feat: configurable request timeout and retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ export MEMOCLAW_PRIVATE_KEY=0x...
 Optionally set a custom API URL:
 ```bash
 export MEMOCLAW_URL=https://api.memoclaw.com  # default
+export MEMOCLAW_TIMEOUT=30000                 # request timeout in ms (default: 30000)
+export MEMOCLAW_MAX_RETRIES=3                 # retries for transient failures (default: 3)
 ```
 
 ### Claude Desktop

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,52 +31,114 @@ export function createApiClient(config: Config) {
     return `${account.address}:${timestamp}:${signature}`;
   }
 
+  /**
+   * Determine if an error/status is transient and worth retrying.
+   */
+  function isTransient(status: number): boolean {
+    return status === 408 || status === 429 || status === 502 || status === 503 || status === 504;
+  }
+
+  /**
+   * Sleep for exponential backoff: base * 2^attempt (with jitter).
+   */
+  function backoff(attempt: number): Promise<void> {
+    const base = 1000;
+    const delay = base * Math.pow(2, attempt) + Math.random() * 500;
+    return new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
   async function makeRequest(method: string, path: string, body?: any) {
     const url = `${apiUrl}${path}`;
-    const headers: Record<string, string> = {};
-    const options: RequestInit = { method, headers };
-    if (body) {
-      headers['Content-Type'] = 'application/json';
-      options.body = JSON.stringify(body);
-    }
+    const { timeout, maxRetries } = config;
+    let lastError: Error | null = null;
 
-    // Try free tier first
-    const walletAuth = await getWalletAuthHeader();
-    headers['x-wallet-auth'] = walletAuth;
-
-    let res = await fetch(url, { ...options, headers });
-
-    // Handle 402 Payment Required (free tier exhausted)
-    if (res.status === 402) {
-      const errorBody = await res.json();
-      const client = getX402Client();
-      const paymentRequired = client.getPaymentRequiredResponse(
-        (name: string) => res.headers.get(name),
-        errorBody
-      );
-
-      const paymentPayload = await client.createPaymentPayload(paymentRequired);
-      const paymentHeaders = client.encodePaymentSignatureHeader(paymentPayload);
-
-      // Ensure Content-Type is preserved on retry when body is present
-      const retryHeaders: Record<string, string> = { ...headers, ...paymentHeaders };
-      if (body && !retryHeaders['Content-Type']) {
-        retryHeaders['Content-Type'] = 'application/json';
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        await backoff(attempt - 1);
       }
 
-      res = await fetch(url, {
-        method,
-        headers: retryHeaders,
-        body: body ? JSON.stringify(body) : undefined,
-      });
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+
+        const headers: Record<string, string> = {};
+        if (body) {
+          headers['Content-Type'] = 'application/json';
+        }
+
+        // Try free tier first
+        const walletAuth = await getWalletAuthHeader();
+        headers['x-wallet-auth'] = walletAuth;
+
+        let res = await fetch(url, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timer);
+
+        // Handle 402 Payment Required (free tier exhausted) — no retry needed
+        if (res.status === 402) {
+          const errorBody = await res.json();
+          const client = getX402Client();
+          const paymentRequired = client.getPaymentRequiredResponse(
+            (name: string) => res.headers.get(name),
+            errorBody
+          );
+
+          const paymentPayload = await client.createPaymentPayload(paymentRequired);
+          const paymentHeaders = client.encodePaymentSignatureHeader(paymentPayload);
+
+          const retryHeaders: Record<string, string> = { ...headers, ...paymentHeaders };
+          if (body && !retryHeaders['Content-Type']) {
+            retryHeaders['Content-Type'] = 'application/json';
+          }
+
+          const controller2 = new AbortController();
+          const timer2 = setTimeout(() => controller2.abort(), timeout);
+
+          res = await fetch(url, {
+            method,
+            headers: retryHeaders,
+            body: body ? JSON.stringify(body) : undefined,
+            signal: controller2.signal,
+          });
+
+          clearTimeout(timer2);
+        }
+
+        // Retry on transient server errors
+        if (isTransient(res.status) && attempt < maxRetries) {
+          lastError = new Error(`HTTP ${res.status}`);
+          continue;
+        }
+
+        if (!res.ok) {
+          const err = await res.text();
+          throw new Error(`HTTP ${res.status}: ${err}`);
+        }
+
+        return res.json();
+      } catch (err: any) {
+        // Retry on network errors and timeouts (but not client errors)
+        if (err.name === 'AbortError') {
+          lastError = new Error(`Request timed out after ${timeout}ms`);
+        } else if (err.message?.startsWith('HTTP 4')) {
+          // Don't retry 4xx (except transient ones handled above)
+          throw err;
+        } else {
+          lastError = err;
+        }
+
+        if (attempt >= maxRetries) {
+          throw lastError;
+        }
+      }
     }
 
-    if (!res.ok) {
-      const err = await res.text();
-      throw new Error(`HTTP ${res.status}: ${err}`);
-    }
-
-    return res.json();
+    throw lastError || new Error('Request failed');
   }
 
   return { makeRequest, account };

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,10 @@ export interface Config {
   privateKey: string;
   apiUrl: string;
   configSource: string;
+  /** Request timeout in milliseconds (default: 30000) */
+  timeout: number;
+  /** Max retries for transient failures (default: 3) */
+  maxRetries: number;
 }
 
 /**
@@ -44,5 +48,10 @@ export function loadConfig(): Config {
     process.exit(1);
   }
 
-  return { privateKey, apiUrl, configSource };
+  const parsedTimeout = parseInt(process.env.MEMOCLAW_TIMEOUT || '', 10);
+  const timeout = Number.isNaN(parsedTimeout) ? 30_000 : parsedTimeout;
+  const parsedRetries = parseInt(process.env.MEMOCLAW_MAX_RETRIES || '', 10);
+  const maxRetries = Number.isNaN(parsedRetries) ? 3 : parsedRetries;
+
+  return { privateKey, apiUrl, configSource, timeout, maxRetries };
 }

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from 'vite
 process.env.MEMOCLAW_PRIVATE_KEY =
   '0x4c0883a69102937d6231471b5dbb6204fe512961708279f15a8f7e20b4e3b1fb';
 process.env.MEMOCLAW_URL = 'https://test.memoclaw.com';
+process.env.MEMOCLAW_TIMEOUT = '5000';
+process.env.MEMOCLAW_MAX_RETRIES = '0';
 
 // Mock MCP SDK
 const mockSetRequestHandler = vi.fn();


### PR DESCRIPTION
## Summary

Adds two reliability improvements to the MCP server API client:

### Request Timeout (MEM-155)
- All API requests now use `AbortSignal` with a configurable timeout
- Default: 30 seconds
- Configure via `MEMOCLAW_TIMEOUT` env var (milliseconds)

### Retry Logic (MEM-154)
- Transient failures (408, 429, 502, 503, 504) and network errors are automatically retried
- Exponential backoff with jitter (1s, 2s, 4s base delays)
- Default: 3 retries, configurable via `MEMOCLAW_MAX_RETRIES`
- No retry on 4xx client errors

### Changes
- `src/config.ts`: Added `timeout` and `maxRetries` config fields
- `src/api.ts`: Rewrote `makeRequest` with timeout + retry loop
- `README.md`: Documented new env vars
- Tests updated and all 147 passing

Closes MEM-155, MEM-154