### PR TITLE
fix: add session management to HTTP transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
 
 import { loadConfig } from './config.js';
 import { createApiClient } from './api.js';
@@ -80,6 +81,9 @@ async function main() {
   if (mode === 'http') {
     const port = getHttpPort();
 
+    // Session store: map session IDs to their transports
+    const sessions = new Map<string, StreamableHTTPServerTransport>();
+
     const httpServer = createServer(async (req, res) => {
       const url = new URL(req.url || '/', `http://localhost:${port}`);
 
@@ -92,11 +96,57 @@ async function main() {
 
       // MCP endpoint
       if (url.pathname === '/mcp') {
+        // Extract session ID from header for existing sessions
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+        if (req.method === 'DELETE') {
+          // Session cleanup
+          if (sessionId && sessions.has(sessionId)) {
+            const transport = sessions.get(sessionId)!;
+            await transport.handleRequest(req, res);
+            sessions.delete(sessionId);
+          } else {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Session not found' }));
+          }
+          return;
+        }
+
+        // For GET (SSE) and POST, route to existing session or create new one
+        if (sessionId && sessions.has(sessionId)) {
+          // Route to existing session transport
+          const transport = sessions.get(sessionId)!;
+          await transport.handleRequest(req, res);
+          return;
+        }
+
+        if (req.method === 'GET') {
+          // GET without valid session → error (SSE needs an existing session)
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid or missing session ID. Send a POST first to initialize.' }));
+          return;
+        }
+
+        // POST without session ID → new session (initialization)
         const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined,
+          sessionIdGenerator: () => randomUUID(),
         });
+
+        // When the transport assigns a session ID, store it
+        transport.onclose = () => {
+          if (transport.sessionId) {
+            sessions.delete(transport.sessionId);
+          }
+        };
+
         await server.connect(transport);
+
+        // Store the session after connect so sessionId is available after first response
         await transport.handleRequest(req, res);
+
+        if (transport.sessionId) {
+          sessions.set(transport.sessionId, transport);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes the Streamable HTTP transport which was creating a new transport per request with no session persistence, breaking stateful MCP interactions.

## Changes

- Generate unique session IDs via `randomUUID()` for each new connection
- Store transports by session ID and route subsequent requests to the correct transport
- Handle `DELETE /mcp` for session cleanup
- Handle `GET /mcp` for SSE streaming (requires existing session)
- Clean up sessions automatically on transport close

## Testing

All 169 existing tests pass. Build succeeds.

Fixes MEM-200