### PR TITLE
feat: add MCP Resources capability (stats, namespaces, core memories)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2,7 +2,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { CallToolRequestSchema, ListToolsRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListToolsRequestSchema, ListResourcesRequestSchema, ReadResourceRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,6 +12,7 @@ import { loadConfig } from './config.js';
 import { createApiClient } from './api.js';
 import { TOOLS } from './tools.js';
 import { createHandler } from './handlers.js';
+import { RESOURCES, createResourceHandler } from './resources.js';
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
 let VERSION = '1.14.0';
@@ -25,9 +26,23 @@ catch {
 const config = loadConfig();
 const api = createApiClient(config);
 const handleToolCall = createHandler(api, config);
-const server = new Server({ name: 'memoclaw', version: VERSION }, { capabilities: { tools: {} } });
+const handleReadResource = createResourceHandler(api, config);
+const server = new Server({ name: 'memoclaw', version: VERSION }, { capabilities: { tools: {}, resources: {} } });
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+// List available resources
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: RESOURCES }));
+// Read a resource
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const { uri } = request.params;
+    try {
+        return await handleReadResource(uri);
+    }
+    catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new Error(`Resource read failed: ${msg}`);
+    }
+});
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,0 +1,115 @@
+/**
+ * MCP Resource definitions and handler for MemoClaw.
+ *
+ * Exposes read-only data as MCP Resources:
+ * - memoclaw://stats        — Memory usage statistics
+ * - memoclaw://namespaces   — List of namespaces with counts
+ * - memoclaw://core-memories — Most important/pinned/frequently accessed memories
+ */
+
+import type { ApiClient } from './api.js';
+import type { Config } from './config.js';
+import { formatMemory } from './format.js';
+
+/** Static resource list returned by resources/list */
+export const RESOURCES = [
+  {
+    uri: 'memoclaw://stats',
+    name: 'Memory Statistics',
+    description:
+      'Usage statistics: total memories, pinned count, average importance, breakdowns by type and namespace. FREE — no API credits used.',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'memoclaw://namespaces',
+    name: 'Namespaces',
+    description:
+      'All namespaces that contain memories, with per-namespace counts. FREE — no API credits used.',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'memoclaw://core-memories',
+    name: 'Core Memories',
+    description:
+      'Your most important memories — high importance, frequently accessed, or pinned. Up to 20 returned. FREE — no API credits used.',
+    mimeType: 'application/json',
+  },
+];
+
+export function createResourceHandler(api: ApiClient, _config: Config) {
+  const { makeRequest } = api;
+
+  return async function handleReadResource(uri: string) {
+    switch (uri) {
+      case 'memoclaw://stats': {
+        const result = await makeRequest('GET', '/v1/stats');
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'application/json',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'memoclaw://namespaces': {
+        let namespaces: any[];
+        try {
+          const result = await makeRequest('GET', '/v1/namespaces');
+          namespaces = result.namespaces || [];
+        } catch {
+          // Fallback: scan memories client-side
+          const nsCounts = new Map<string, number>();
+          let offset = 0;
+          const pageSize = 100;
+          for (let page = 0; page < 200; page++) {
+            const params = new URLSearchParams();
+            params.set('limit', String(pageSize));
+            params.set('offset', String(offset));
+            const result = await makeRequest('GET', `/v1/memories?${params}`);
+            const memories = result.memories || result.data || [];
+            if (memories.length === 0) break;
+            for (const m of memories) {
+              const ns = m.namespace || '(default)';
+              nsCounts.set(ns, (nsCounts.get(ns) || 0) + 1);
+            }
+            if (memories.length < pageSize) break;
+            offset += pageSize;
+          }
+          namespaces = [...nsCounts.entries()].map(([namespace, count]) => ({
+            namespace,
+            count,
+          }));
+        }
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'application/json',
+              text: JSON.stringify({ namespaces }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'memoclaw://core-memories': {
+        const result = await makeRequest('GET', '/v1/core-memories?limit=20');
+        const memories = result.memories || result.core_memories || result.data || [];
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'application/json',
+              text: JSON.stringify({ memories, count: memories.length }, null, 2),
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown resource: ${uri}`);
+    }
+  };
+}

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for MCP Resources capability.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+process.env.MEMOCLAW_PRIVATE_KEY =
+  '0x4c0883a69102937d6231471b5dbb6204fe512961708279f15a8f7e20b4e3b1fb';
+process.env.MEMOCLAW_URL = 'https://test.memoclaw.com';
+process.env.MEMOCLAW_TIMEOUT = '5000';
+process.env.MEMOCLAW_MAX_RETRIES = '0';
+
+// Must mock fetch before importing modules
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { RESOURCES, createResourceHandler } from '../src/resources.js';
+import { loadConfig } from '../src/config.js';
+import { createApiClient } from '../src/api.js';
+
+describe('Resources', () => {
+  let handleReadResource: ReturnType<typeof createResourceHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const config = loadConfig();
+    const api = createApiClient(config);
+    handleReadResource = createResourceHandler(api, config);
+  });
+
+  function mockApiResponse(data: any, status = 200) {
+    mockFetch.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => data,
+      text: async () => JSON.stringify(data),
+      headers: new Headers(),
+    });
+  }
+
+  describe('RESOURCES list', () => {
+    it('should define three resources', () => {
+      expect(RESOURCES).toHaveLength(3);
+      const uris = RESOURCES.map((r) => r.uri);
+      expect(uris).toContain('memoclaw://stats');
+      expect(uris).toContain('memoclaw://namespaces');
+      expect(uris).toContain('memoclaw://core-memories');
+    });
+
+    it('all resources have required fields', () => {
+      for (const r of RESOURCES) {
+        expect(r.uri).toBeTruthy();
+        expect(r.name).toBeTruthy();
+        expect(r.description).toBeTruthy();
+        expect(r.mimeType).toBe('application/json');
+      }
+    });
+  });
+
+  describe('memoclaw://stats', () => {
+    it('should return stats as JSON', async () => {
+      const statsData = {
+        total_memories: 42,
+        pinned_count: 5,
+        avg_importance: 0.65,
+      };
+      mockApiResponse(statsData);
+
+      const result = await handleReadResource('memoclaw://stats');
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0].uri).toBe('memoclaw://stats');
+      expect(result.contents[0].mimeType).toBe('application/json');
+      const parsed = JSON.parse(result.contents[0].text);
+      expect(parsed.total_memories).toBe(42);
+    });
+  });
+
+  describe('memoclaw://namespaces', () => {
+    it('should return namespaces from API', async () => {
+      const nsData = {
+        namespaces: [
+          { namespace: 'work', count: 10 },
+          { namespace: 'personal', count: 5 },
+        ],
+      };
+      mockApiResponse(nsData);
+
+      const result = await handleReadResource('memoclaw://namespaces');
+      expect(result.contents).toHaveLength(1);
+      const parsed = JSON.parse(result.contents[0].text);
+      expect(parsed.namespaces).toHaveLength(2);
+    });
+  });
+
+  describe('memoclaw://core-memories', () => {
+    it('should return core memories', async () => {
+      const coreData = {
+        memories: [
+          { id: '1', content: 'Important thing', importance: 1.0, pinned: true },
+        ],
+      };
+      mockApiResponse(coreData);
+
+      const result = await handleReadResource('memoclaw://core-memories');
+      expect(result.contents).toHaveLength(1);
+      const parsed = JSON.parse(result.contents[0].text);
+      expect(parsed.memories).toHaveLength(1);
+      expect(parsed.count).toBe(1);
+    });
+  });
+
+  describe('unknown resource', () => {
+    it('should throw for unknown URI', async () => {
+      await expect(handleReadResource('memoclaw://unknown')).rejects.toThrow(
+        'Unknown resource'
+      );
+    });
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -28,6 +28,8 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
   ListToolsRequestSchema: 'ListToolsRequestSchema',
   CallToolRequestSchema: 'CallToolRequestSchema',
+  ListResourcesRequestSchema: 'ListResourcesRequestSchema',
+  ReadResourceRequestSchema: 'ReadResourceRequestSchema',
 }));
 
 vi.mock('@x402/core/client', () => ({
@@ -81,7 +83,7 @@ function mockFetchError(status: number, text: string) {
 
 describe('Tool Definitions', () => {
   it('registers both handlers', () => {
-    expect(mockSetRequestHandler).toHaveBeenCalledTimes(2);
+    expect(mockSetRequestHandler).toHaveBeenCalledTimes(4);
   });
 
   it('exposes all expected tools', async () => {


### PR DESCRIPTION
## Summary

Adds MCP Resources support to the server, exposing three read-only resources:

- `memoclaw://stats` — Memory usage statistics  
- `memoclaw://namespaces` — Namespace list with counts  
- `memoclaw://core-memories` — Most important/pinned/frequently accessed memories

All three are **FREE** (no API credits used).

## Changes

- New `src/resources.ts` — resource definitions and read handler
- Updated `src/index.ts` — register `resources: {}` capability, add ListResources and ReadResource handlers
- New `tests/resources.test.ts` — 5 tests covering all resources + unknown URI error
- Updated `tests/tools.test.ts` — mock new SDK schemas, update handler count assertion

## Testing

All 175 tests pass.

Closes MEM-198