### PR TITLE
chore: update @x402/core and @x402/evm to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,9 +1193,9 @@
       }
     },
     "node_modules/@x402/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-g4K5dAVjevQftxCcpFlUDjO2AHE43FkO43VxwLCQ8ET3ki4aj2fzCcgvnXEj2eloJoocFS/Evt4pSTnP/4cFJw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-nUr8HW8WhkU1DvrpUfsRvALy5NF8UWKoFezZOtX61mohxp2lWZpJ2GnvscxDM8nmBAbtIollmksd5z5pj8InXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.2"
@@ -1211,13 +1211,13 @@
       }
     },
     "node_modules/@x402/evm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.4.0.tgz",
-      "integrity": "sha512-k9qIEhJ5m8jZLPA44hcLEP9I1WC8nF375A7pX/3XGPA+H2UPUoY8fzBaQA2U+4lMv/eIyfz05klSj/8LzP1saA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.5.0.tgz",
+      "integrity": "sha512-MBSTQZwLobMVcmYO7itOMJRkxfHstsDyr7F94o9Rk/Oinz0kjvCe4DFgZmFXyz3nQUgQFmDVgTK5KIzfYR5uIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@x402/core": "~2.4.0",
-        "@x402/extensions": "~2.4.0",
+        "@x402/core": "~2.5.0",
+        "@x402/extensions": "~2.5.0",
         "viem": "^2.39.3",
         "zod": "^3.24.2"
       }
@@ -1232,13 +1232,13 @@
       }
     },
     "node_modules/@x402/extensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.4.0.tgz",
-      "integrity": "sha512-tg/mSAS+NgwUaOdjt8agSjVkO1s9NYy+kSPubVlZf/Fy884qu7dSW81Ixu1NRYEz+vBk0rtz6b+eEvS0v72tMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.5.0.tgz",
+      "integrity": "sha512-e7IQShbGUM/XQmzI8DQh2tX/k2XDUGI9DNF+ij2NHUyPEqAt5/mJCwOlaxS/60FWFdfFRfWjTsqaoS7Z8WLi+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.2.6",
-        "@x402/core": "~2.4.0",
+        "@x402/core": "~2.5.0",
         "ajv": "^8.17.1",
         "siwe": "^2.3.2",
         "tweetnacl": "^1.0.3",


### PR DESCRIPTION
Updates x402 payment dependencies from 2.4.0 to 2.5.0. All 189 tests pass.