### PR TITLE
fix: add session TTL cleanup for HTTP transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,8 +121,33 @@ async function main() {
   if (mode === 'http') {
     const port = getHttpPort();
 
-    // Session store: map session IDs to their transports
+    // Session store: map session IDs to their transports + last activity time
     const sessions = new Map<string, StreamableHTTPServerTransport>();
+    const sessionActivity = new Map<string, number>();
+
+    /** Session idle TTL in ms (default 30 min, configurable via MEMOCLAW_SESSION_TTL_MS) */
+    const SESSION_TTL_MS = parseInt(process.env.MEMOCLAW_SESSION_TTL_MS || '', 10) || 30 * 60 * 1000;
+
+    /** Sweep interval to clean up idle sessions (every 5 min) */
+    const sweepInterval = setInterval(() => {
+      const now = Date.now();
+      for (const [id, lastActive] of sessionActivity) {
+        if (now - lastActive > SESSION_TTL_MS) {
+          const transport = sessions.get(id);
+          if (transport) {
+            try { transport.close?.(); } catch { /* ignore */ }
+          }
+          sessions.delete(id);
+          sessionActivity.delete(id);
+        }
+      }
+    }, 5 * 60 * 1000);
+    sweepInterval.unref(); // Don't prevent process exit
+
+    /** Touch session activity timestamp */
+    function touchSession(id: string) {
+      sessionActivity.set(id, Date.now());
+    }
 
     const httpServer = createServer(async (req, res) => {
       const url = new URL(req.url || '/', `http://localhost:${port}`);
@@ -130,7 +155,7 @@ async function main() {
       // Health check endpoint
       if (url.pathname === '/health' && req.method === 'GET') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', version: VERSION }));
+        res.end(JSON.stringify({ status: 'ok', version: VERSION, activeSessions: sessions.size }));
         return;
       }
 
@@ -145,6 +170,7 @@ async function main() {
             const transport = sessions.get(sessionId)!;
             await transport.handleRequest(req, res);
             sessions.delete(sessionId);
+            sessionActivity.delete(sessionId);
           } else {
             res.writeHead(404, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'Session not found' }));
@@ -156,6 +182,7 @@ async function main() {
         if (sessionId && sessions.has(sessionId)) {
           // Route to existing session transport
           const transport = sessions.get(sessionId)!;
+          touchSession(sessionId);
           await transport.handleRequest(req, res);
           return;
         }
@@ -176,6 +203,7 @@ async function main() {
         transport.onclose = () => {
           if (transport.sessionId) {
             sessions.delete(transport.sessionId);
+            sessionActivity.delete(transport.sessionId);
           }
         };
 
@@ -186,6 +214,7 @@ async function main() {
 
         if (transport.sessionId) {
           sessions.set(transport.sessionId, transport);
+          touchSession(transport.sessionId);
         }
         return;
       }


### PR DESCRIPTION
## Problem
Abandoned HTTP sessions were never cleaned up, causing unbounded memory growth in long-running deployments. If a client connects via POST but never sends DELETE, the session object lives forever.

## Solution
- Track last-activity timestamps per session
- Periodic sweep (every 5 min) removes sessions idle > TTL (default 30 min)
- TTL configurable via `MEMOCLAW_SESSION_TTL_MS` env var
- `/health` endpoint now reports `activeSessions` count for observability
- Cleanup also removes activity tracking entries on session close/delete

## Testing
All 196 existing tests pass. Build succeeds.

Closes #73