### PR TITLE
feat: add MCP completions for namespace, tag, and memory_type arguments

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,95 @@
+/**
+ * MCP Completion handler for MemoClaw.
+ *
+ * Provides autocomplete suggestions for prompt and resource template arguments.
+ * Cached values are refreshed every 5 minutes to avoid excessive API calls.
+ */
+
+import type { ApiClient } from './api.js';
+import type { Config } from './config.js';
+
+const MEMORY_TYPES = ['correction', 'preference', 'decision', 'project', 'observation', 'general'];
+
+/** Simple TTL cache for namespace and tag lists */
+interface CacheEntry<T> {
+  data: T;
+  expiry: number;
+}
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export function createCompletionHandler(api: ApiClient, _config: Config) {
+  const { makeRequest } = api;
+
+  let nsCache: CacheEntry<string[]> | null = null;
+  let tagCache: CacheEntry<string[]> | null = null;
+
+  async function getNamespaces(): Promise<string[]> {
+    if (nsCache && Date.now() < nsCache.expiry) return nsCache.data;
+    try {
+      const result = await makeRequest('GET', '/v1/namespaces');
+      const namespaces = (result.namespaces || []).map((ns: any) =>
+        typeof ns === 'string' ? ns : ns.namespace || ns.name
+      ).filter(Boolean);
+      nsCache = { data: namespaces, expiry: Date.now() + CACHE_TTL };
+      return namespaces;
+    } catch {
+      return nsCache?.data || [];
+    }
+  }
+
+  async function getTags(): Promise<string[]> {
+    if (tagCache && Date.now() < tagCache.expiry) return tagCache.data;
+    try {
+      const result = await makeRequest('GET', '/v1/tags');
+      const tags = (result.tags || []).map((t: any) =>
+        typeof t === 'string' ? t : t.tag || t.name
+      ).filter(Boolean);
+      tagCache = { data: tags, expiry: Date.now() + CACHE_TTL };
+      return tags;
+    } catch {
+      return tagCache?.data || [];
+    }
+  }
+
+  /** Filter and return matching completions for a partial value */
+  function filterValues(values: string[], partial: string): { values: string[]; total: number; hasMore: boolean } {
+    const lower = partial.toLowerCase();
+    const matched = lower
+      ? values.filter((v) => v.toLowerCase().includes(lower))
+      : values;
+    return {
+      values: matched.slice(0, 100),
+      total: matched.length,
+      hasMore: matched.length > 100,
+    };
+  }
+
+  return async function handleComplete(
+    ref: { type: string; name?: string; uri?: string },
+    argument: { name: string; value: string }
+  ): Promise<{ completion: { values: string[]; total?: number; hasMore?: boolean } }> {
+    const argName = argument.name;
+    const partial = argument.value;
+
+    // Provide completions for 'namespace' argument
+    if (argName === 'namespace') {
+      const namespaces = await getNamespaces();
+      return { completion: filterValues(namespaces, partial) };
+    }
+
+    // Provide completions for 'tag' argument
+    if (argName === 'tag') {
+      const tags = await getTags();
+      return { completion: filterValues(tags, partial) };
+    }
+
+    // Provide completions for 'memory_type' argument
+    if (argName === 'memory_type') {
+      return { completion: filterValues(MEMORY_TYPES, partial) };
+    }
+
+    // No completions available for this argument
+    return { completion: { values: [] } };
+  };
+}

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCompletionHandler } from '../src/completions.js';
+import type { ApiClient } from '../src/api.js';
+import type { Config } from '../src/config.js';
+
+const mockConfig: Config = {
+  privateKey: '0x1234',
+  apiUrl: 'https://api.memoclaw.com',
+  configSource: 'test',
+  timeout: 5000,
+  maxRetries: 0,
+};
+
+describe('Completions', () => {
+  let mockMakeRequest: ReturnType<typeof vi.fn>;
+  let handleComplete: ReturnType<typeof createCompletionHandler>;
+
+  beforeEach(() => {
+    mockMakeRequest = vi.fn();
+    const mockApi = {
+      makeRequest: mockMakeRequest,
+      account: { address: '0xtest' },
+    } as unknown as ApiClient;
+    handleComplete = createCompletionHandler(mockApi, mockConfig);
+  });
+
+  it('returns namespace completions', async () => {
+    mockMakeRequest.mockResolvedValueOnce({
+      namespaces: [{ namespace: 'work', count: 5 }, { namespace: 'personal', count: 3 }],
+    });
+
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'review-memories' },
+      { name: 'namespace', value: 'wo' }
+    );
+
+    expect(result.completion.values).toEqual(['work']);
+    expect(mockMakeRequest).toHaveBeenCalledWith('GET', '/v1/namespaces');
+  });
+
+  it('returns all namespaces when value is empty', async () => {
+    mockMakeRequest.mockResolvedValueOnce({
+      namespaces: [{ namespace: 'work', count: 5 }, { namespace: 'personal', count: 3 }],
+    });
+
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'review-memories' },
+      { name: 'namespace', value: '' }
+    );
+
+    expect(result.completion.values).toEqual(['work', 'personal']);
+  });
+
+  it('returns tag completions', async () => {
+    mockMakeRequest.mockResolvedValueOnce({
+      tags: ['frontend', 'backend', 'infra'],
+    });
+
+    const result = await handleComplete(
+      { type: 'ref/resource', uri: 'memoclaw://tags/{tag}' },
+      { name: 'tag', value: 'front' }
+    );
+
+    expect(result.completion.values).toEqual(['frontend']);
+  });
+
+  it('returns memory_type completions', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'load-context' },
+      { name: 'memory_type', value: 'cor' }
+    );
+
+    expect(result.completion.values).toEqual(['correction']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns empty for unknown arguments', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'load-context' },
+      { name: 'unknown_arg', value: 'test' }
+    );
+
+    expect(result.completion.values).toEqual([]);
+  });
+
+  it('caches namespace results', async () => {
+    mockMakeRequest.mockResolvedValue({
+      namespaces: [{ namespace: 'work', count: 5 }],
+    });
+
+    await handleComplete(
+      { type: 'ref/prompt' },
+      { name: 'namespace', value: '' }
+    );
+    await handleComplete(
+      { type: 'ref/prompt' },
+      { name: 'namespace', value: 'w' }
+    );
+
+    expect(mockMakeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockMakeRequest.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await handleComplete(
+      { type: 'ref/prompt' },
+      { name: 'namespace', value: '' }
+    );
+
+    expect(result.completion.values).toEqual([]);
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -33,6 +33,7 @@ vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
   ReadResourceRequestSchema: 'ReadResourceRequestSchema',
   ListPromptsRequestSchema: 'ListPromptsRequestSchema',
   GetPromptRequestSchema: 'GetPromptRequestSchema',
+  CompleteRequestSchema: 'CompleteRequestSchema',
 }));
 
 vi.mock('@x402/core/client', () => ({
@@ -86,7 +87,7 @@ function mockFetchError(status: number, text: string) {
 
 describe('Tool Definitions', () => {
   it('registers both handlers', () => {
-    expect(mockSetRequestHandler).toHaveBeenCalledTimes(7);
+    expect(mockSetRequestHandler).toHaveBeenCalledTimes(8);
   });
 
   it('exposes all expected tools', async () => {


### PR DESCRIPTION
## Summary

Implements the `completion/complete` MCP capability to provide autocomplete suggestions for prompt and resource template arguments.

### What's new

- **Namespace completions** — fetches existing namespaces from `/v1/namespaces` (cached 5min)
- **Tag completions** — fetches existing tags from `/v1/tags` (cached 5min)
- **Memory type completions** — static enum values (correction, preference, decision, etc.)

### How it works

When MCP clients (Claude Desktop, etc.) request completions for prompt or resource template arguments, the server now returns matching suggestions. For example, typing `wo` in a namespace field will suggest `work`.

### Files changed

- `src/completions.ts` — new completion handler with TTL caching
- `src/index.ts` — wire up CompleteRequestSchema handler + completions capability
- `tests/completions.test.ts` — 7 new tests covering all completion types
- `tests/tools.test.ts` — updated mock and handler count

### Tests

All 203 tests passing (7 new + 196 existing).