### PR TITLE
fix: CLI flags, bulk limit, consolidate agent_id, graceful shutdown

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -175,9 +175,10 @@ export function createHandler(api: ApiClient, config: Config) {
       }
 
       case 'memoclaw_consolidate': {
-        const { namespace, min_similarity, mode, dry_run } = args;
+        const { namespace, min_similarity, mode, dry_run, agent_id } = args;
         const body: any = {};
         if (namespace) body.namespace = namespace;
+        if (agent_id) body.agent_id = agent_id;
         if (min_similarity !== undefined) body.min_similarity = min_similarity;
         if (mode) body.mode = mode;
         if (dry_run !== undefined) body.dry_run = dry_run;
@@ -334,7 +335,7 @@ export function createHandler(api: ApiClient, config: Config) {
         if (!memories || !Array.isArray(memories) || memories.length === 0) {
           throw new Error('memories is required and must be a non-empty array');
         }
-        if (memories.length > 50) throw new Error('Maximum 50 memories per bulk store call');
+        if (memories.length > 100) throw new Error('Maximum 100 memories per bulk store call');
         for (const [i, m] of memories.entries()) {
           if (!m.content || (typeof m.content === 'string' && m.content.trim() === '')) {
             throw new Error(`Memory at index ${i} has empty content`);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -282,6 +282,7 @@ export const TOOLS = [
       type: 'object' as const,
       properties: {
         namespace: { type: 'string', description: 'Only consolidate within this namespace.' },
+        agent_id: { type: 'string', description: 'Only consolidate memories for this agent.' },
         min_similarity: { type: 'number', description: 'Minimum similarity for duplicates (0.0-1.0).' },
         mode: { type: 'string', description: 'Consolidation strategy/mode.' },
         dry_run: { type: 'boolean', description: 'If true, returns what WOULD be merged without actually merging.' },
@@ -428,7 +429,7 @@ export const TOOLS = [
   {
     name: 'memoclaw_bulk_store',
     description:
-      'Store multiple memories in a single call. Max 50 per call. ' +
+      'Store multiple memories in a single call. Max 100 per call. ' +
       'Each memory can have its own tags, namespace, importance, etc.',
     annotations: {
       title: 'Bulk store memories',

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1026,13 +1026,13 @@ describe('Tool Handlers', () => {
     expect(result.content[0].text).toContain('non-empty array');
   });
 
-  it('bulk_store with >50 memories returns error', async () => {
-    const memories = Array.from({ length: 51 }, (_, i) => ({ content: `m${i}` }));
+  it('bulk_store with >100 memories returns error', async () => {
+    const memories = Array.from({ length: 101 }, (_, i) => ({ content: `m${i}` }));
     const result = await callToolHandler({
       params: { name: 'memoclaw_bulk_store', arguments: { memories } },
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Maximum 50');
+    expect(result.content[0].text).toContain('Maximum 100');
   });
 
   it('bulk_store rejects memory exceeding 8192 chars', async () => {


### PR DESCRIPTION
## Changes

- **CLI flags**: Add `--version/-v` and `--help/-h` flags, handled before config load so they work without a private key
- **Bulk store limit**: Raise from 50 to 100 memories per call (matches API batch endpoint capacity)
- **Consolidate agent_id**: Add missing `agent_id` parameter to consolidate tool schema and handler
- **Graceful shutdown**: Handle SIGINT/SIGTERM to cleanly close the MCP server

## Testing
All 196 tests pass. Build clean.