### PR TITLE
fix: Origin header validation, batch API endpoints, and bug fixes

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -268,7 +268,11 @@ export function createHandler(api: ApiClient, config: Config) {
             ? list.map((m: any) => JSON.stringify(m)).join('\n')
             : JSON.stringify(list, null, 2);
           return { content: [{ type: 'text', text: `📦 Exported ${list.length} memories\n\n${output}` }] };
-        } catch {
+        } catch (exportErr: any) {
+          // Only fall back to pagination if /v1/export is not found (404)
+          if (!exportErr.message?.includes('404') && !exportErr.message?.includes('Not Found')) {
+            throw exportErr;
+          }
           // Fallback: paginate through /v1/memories if /v1/export is unavailable
           const allMemories: any[] = [];
           let offset = 0;
@@ -305,6 +309,38 @@ export function createHandler(api: ApiClient, config: Config) {
           validateContentLength(m.content, `Memory at index ${i}`);
           validateImportance(m.importance, `Memory at index ${i} importance`);
         }
+
+        const IMPORT_FIELDS = ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'immutable'];
+
+        // Try batch API endpoint first
+        try {
+          const batchBody: any = {
+            memories: memories.map((m: any) => {
+              const item: any = {};
+              for (const key of IMPORT_FIELDS) {
+                if (m[key] !== undefined) item[key] = m[key];
+              }
+              if (session_id) item.session_id = session_id;
+              if (agent_id) item.agent_id = agent_id;
+              return item;
+            }),
+          };
+          const result = await makeRequest('POST', '/v1/store/batch', batchBody);
+          const stored = result.memories || result.data || [];
+          const failedItems = result.failed || [];
+          let text = `📥 Import: ${stored.length} stored, ${failedItems.length} failed`;
+          if (failedItems.length > 0) {
+            const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
+            text += `\n\nErrors:\n${errors.join('\n')}`;
+          }
+          return { content: [{ type: 'text', text }] };
+        } catch (batchErr: any) {
+          if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
+            throw batchErr;
+          }
+        }
+
+        // Fallback: store one-by-one with concurrency
         const results = await withConcurrency(
           memories.map((m: any) => () => {
             const body: any = { content: m.content };
@@ -344,6 +380,38 @@ export function createHandler(api: ApiClient, config: Config) {
           validateImportance(m.importance, `Memory at index ${i} importance`);
         }
         const STORE_FIELDS = ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'expires_at', 'immutable'];
+
+        // Try batch API endpoint first (single request), fall back to one-by-one
+        try {
+          const batchBody: any = {
+            memories: memories.map((m: any) => {
+              const item: any = {};
+              for (const key of STORE_FIELDS) {
+                if (m[key] !== undefined) item[key] = m[key];
+              }
+              if (session_id) item.session_id = session_id;
+              if (agent_id) item.agent_id = agent_id;
+              return item;
+            }),
+          };
+          const result = await makeRequest('POST', '/v1/store/batch', batchBody);
+          const stored = result.memories || result.data || [];
+          const failedItems = result.failed || [];
+          let text = `✅ Bulk store: ${stored.length} stored, ${failedItems.length} failed`;
+          if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
+          if (failedItems.length > 0) {
+            const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
+            text += `\n\nErrors:\n${errors.join('\n')}`;
+          }
+          return { content: [{ type: 'text', text }] };
+        } catch (batchErr: any) {
+          // Fall back to one-by-one if batch endpoint is unavailable (404)
+          if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
+            throw batchErr;
+          }
+        }
+
+        // Fallback: store one-by-one with concurrency
         const results = await withConcurrency(
           memories.map((m: any) => () => {
             const body: any = {};
@@ -406,7 +474,7 @@ export function createHandler(api: ApiClient, config: Config) {
                 if (items.length < pageSize) { total = counted; break; }
                 offset += pageSize;
               }
-              if (typeof total === 'undefined') total = `${counted}+`;
+              if (total === 'unknown') total = `${counted}+`;
             }
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ Environment variables:
   MEMOCLAW_MAX_RETRIES    Max retries for transient failures (default: 3)
   MEMOCLAW_HTTP_TOKEN     Bearer token for HTTP transport auth (optional)
   MEMOCLAW_SESSION_TTL_MS Session idle TTL in ms (default: 1800000)
+  MEMOCLAW_ALLOWED_ORIGINS Comma-separated allowed origins for HTTP transport
+                           (default: localhost only; set to * to allow all)
 
 More info: https://docs.memoclaw.com`);
   process.exit(0);
@@ -195,14 +197,57 @@ async function main() {
 
     const httpToken = getHttpToken();
 
+    /**
+     * Allowed origins for HTTP transport.
+     * Validates Origin header to prevent DNS rebinding attacks.
+     * Set MEMOCLAW_ALLOWED_ORIGINS to a comma-separated list of origins,
+     * or leave unset to allow only localhost/127.0.0.1 origins by default.
+     */
+    function getAllowedOrigins(): Set<string> | 'any' {
+      const env = process.env.MEMOCLAW_ALLOWED_ORIGINS;
+      if (env === '*') return 'any';
+      if (env) {
+        return new Set(env.split(',').map((o) => o.trim().toLowerCase()).filter(Boolean));
+      }
+      // Default: allow localhost origins only (prevents DNS rebinding)
+      return new Set([
+        `http://localhost:${port}`,
+        `http://127.0.0.1:${port}`,
+        `http://[::1]:${port}`,
+      ]);
+    }
+
+    const allowedOrigins = getAllowedOrigins();
+
+    /**
+     * Check if the Origin header is allowed.
+     * Requests without an Origin header are allowed (non-browser clients, stdio proxies).
+     * Requests WITH an Origin must match the allowlist to prevent DNS rebinding.
+     */
+    function isOriginAllowed(origin: string | undefined): boolean {
+      if (!origin) return true; // Non-browser clients (curl, SDK, stdio proxy)
+      if (allowedOrigins === 'any') return true;
+      return allowedOrigins.has(origin.toLowerCase());
+    }
+
     const httpServer = createServer(async (req, res) => {
       const url = new URL(req.url || '/', `http://localhost:${port}`);
 
-      // Health check endpoint (no auth required)
+      // Health check endpoint (no auth required, no origin check)
       if (url.pathname === '/health' && req.method === 'GET') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ status: 'ok', version: VERSION, activeSessions: sessions.size }));
         return;
+      }
+
+      // Origin validation for /mcp to prevent DNS rebinding attacks
+      if (url.pathname === '/mcp') {
+        const origin = req.headers['origin'] as string | undefined;
+        if (!isOriginAllowed(origin)) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: `Origin "${origin}" is not allowed. Set MEMOCLAW_ALLOWED_ORIGINS to configure.` }));
+          return;
+        }
       }
 
       // Bearer token auth for /mcp when MEMOCLAW_HTTP_TOKEN is set

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -998,8 +998,8 @@ describe('Tool Handlers', () => {
     expect(result.content[0].text).toContain('index 1');
   });
 
-  it('import succeeds', async () => {
-    globalThis.fetch = mockFetchOk({ memory: { id: '1', content: 'test' } });
+  it('import succeeds via batch endpoint', async () => {
+    globalThis.fetch = mockFetchOk({ memories: [{ id: '1', content: 'a' }, { id: '2', content: 'b' }], failed: [] });
     const result = await callToolHandler({
       params: { name: 'memoclaw_import', arguments: { memories: [{ content: 'a' }, { content: 'b' }] } },
     });
@@ -1007,14 +1007,15 @@ describe('Tool Handlers', () => {
     expect(result.content[0].text).toContain('0 failed');
   });
 
-  it('import passes session_id and agent_id to each memory', async () => {
-    globalThis.fetch = mockFetchOk({ memory: { id: '1', content: 'test' } });
+  it('import passes session_id and agent_id to each memory in batch', async () => {
+    globalThis.fetch = mockFetchOk({ memories: [{ id: '1', content: 'a' }], failed: [] });
     await callToolHandler({
       params: { name: 'memoclaw_import', arguments: { memories: [{ content: 'a' }], session_id: 's1', agent_id: 'ag1' } },
     });
     const body = JSON.parse((globalThis.fetch as any).mock.calls[0][1].body);
-    expect(body.session_id).toBe('s1');
-    expect(body.agent_id).toBe('ag1');
+    // Batch endpoint sends { memories: [{ content, session_id, agent_id }] }
+    expect(body.memories[0].session_id).toBe('s1');
+    expect(body.memories[0].agent_id).toBe('ag1');
   });
 
   // --- Bulk Store ---
@@ -1061,8 +1062,38 @@ describe('Tool Handlers', () => {
     expect(result.content[0].text).toContain('index 1');
   });
 
-  it('bulk_store succeeds', async () => {
-    globalThis.fetch = mockFetchOk({ memory: { id: '1', content: 'test' } });
+  it('bulk_store succeeds via batch endpoint', async () => {
+    globalThis.fetch = mockFetchOk({ memories: [{ id: '1', content: 'a' }, { id: '2', content: 'b' }], failed: [] });
+    const result = await callToolHandler({
+      params: { name: 'memoclaw_bulk_store', arguments: { memories: [{ content: 'a' }, { content: 'b' }] } },
+    });
+    expect(result.content[0].text).toContain('2 stored');
+    expect(result.content[0].text).toContain('0 failed');
+  });
+
+  it('bulk_store falls back to one-by-one when batch endpoint returns 404', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call is to /v1/store/batch → 404
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({ error: 'Not Found' }),
+          text: () => Promise.resolve('HTTP 404: Not Found'),
+          headers: new Headers(),
+        });
+      }
+      // Subsequent calls are individual /v1/store
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ memory: { id: String(callCount), content: 'test' } }),
+        text: () => Promise.resolve('{}'),
+        headers: new Headers(),
+      });
+    });
     const result = await callToolHandler({
       params: { name: 'memoclaw_bulk_store', arguments: { memories: [{ content: 'a' }, { content: 'b' }] } },
     });
@@ -1253,13 +1284,14 @@ describe('Tool Handlers', () => {
   // --- Bulk Store field whitelisting ---
 
   it('bulk_store does not leak extra fields to API', async () => {
-    globalThis.fetch = mockFetchOk({ memory: { id: '1', content: 'test' } });
+    globalThis.fetch = mockFetchOk({ memories: [{ id: '1', content: 'ok' }], failed: [] });
     await callToolHandler({
       params: { name: 'memoclaw_bulk_store', arguments: { memories: [{ content: 'ok', extra_bad_field: 'should not appear' }] } },
     });
     const body = JSON.parse((globalThis.fetch as any).mock.calls[0][1].body);
-    expect(body.content).toBe('ok');
-    expect(body.extra_bad_field).toBeUndefined();
+    // Now sends to /v1/store/batch with { memories: [...] }
+    expect(body.memories[0].content).toBe('ok');
+    expect(body.memories[0].extra_bad_field).toBeUndefined();
   });
 
   // --- Init tool ---


### PR DESCRIPTION
## Changes

### Security: Origin header validation (Fixes #80)
- Validates `Origin` header on HTTP transport to prevent DNS rebinding attacks
- Configurable via `MEMOCLAW_ALLOWED_ORIGINS` env var (comma-separated)
- Default: localhost only (`http://localhost:<port>`, `127.0.0.1`, `[::1]`)
- Set to `*` to allow all origins
- Requests without Origin header (non-browser clients) are allowed through

### Performance: Batch API endpoints (Fixes #68)
- `memoclaw_bulk_store` now tries `/v1/store/batch` first (single HTTP request)
- `memoclaw_import` now tries `/v1/store/batch` first
- Both fall back to one-by-one with concurrency if batch endpoint returns 404
- Reduces API calls from N to 1 when batch endpoint is available

### Bug fixes
- **Export fallback too broad**: `memoclaw_export` was catching ALL errors and falling back to pagination. Now only falls back on 404 (endpoint not found). Server errors (500, etc.) properly propagate.
- **Count unreachable code**: Fixed `typeof total === 'undefined'` check that could never trigger since `total` was initialized to `'unknown'` string. Now correctly checks `total === 'unknown'`.

### Tests
- Updated bulk_store and import tests for batch endpoint behavior
- Added fallback test for bulk_store when batch returns 404
- All 204 tests pass ✅