### PR TITLE
feat: Add MCP logging capability for debugging and observability

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import { ExactEvmScheme } from '@x402/evm/exact/client';
 import { toClientEvmSigner } from '@x402/evm';
 import { privateKeyToAccount } from 'viem/accounts';
 import type { Config } from './config.js';
+import { mcpLogger } from './logging.js';
 
 export function createApiClient(config: Config) {
   const account = privateKeyToAccount(config.privateKey as `0x${string}`);
@@ -54,6 +55,7 @@ export function createApiClient(config: Config) {
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
+        mcpLogger.debug('api', { event: 'retry', method, path, attempt });
         await backoff(attempt - 1);
       }
 
@@ -81,6 +83,7 @@ export function createApiClient(config: Config) {
 
         // Handle 402 Payment Required (free tier exhausted) — no retry needed
         if (res.status === 402) {
+          mcpLogger.info('api', { event: 'payment_required', method, path, message: 'Free tier exhausted, using x402 payment' });
           const errorBody = await res.json();
           const client = getX402Client();
           const paymentRequired = client.getPaymentRequiredResponse(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
   CompleteRequestSchema,
+  SetLevelRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
@@ -25,6 +26,8 @@ import { createHandler } from './handlers.js';
 import { RESOURCES, RESOURCE_TEMPLATES, createResourceHandler } from './resources.js';
 import { PROMPTS, createPromptHandler } from './prompts.js';
 import { createCompletionHandler } from './completions.js';
+import { mcpLogger } from './logging.js';
+import type { LogLevel } from './logging.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -75,8 +78,11 @@ const handleComplete = createCompletionHandler(api, config);
 
 const server = new Server(
   { name: 'memoclaw', version: VERSION },
-  { capabilities: { tools: {}, resources: {}, prompts: {}, completions: {} } }
+  { capabilities: { tools: {}, resources: {}, prompts: {}, completions: {}, logging: {} } }
 );
+
+// Attach logger to server for sending notifications to clients
+mcpLogger.attach(server);
 
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
@@ -90,10 +96,12 @@ server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ reso
 // Read a resource
 server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   const { uri } = request.params;
+  mcpLogger.debug('resource', { event: 'read', uri });
   try {
     return await handleReadResource(uri);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    mcpLogger.error('resource', { event: 'error', uri, error: msg });
     throw new Error(`Resource read failed: ${msg}`);
   }
 });
@@ -118,13 +126,25 @@ server.setRequestHandler(CompleteRequestSchema, async (request) => {
   return await handleComplete(ref, argument);
 });
 
+// Handle logging level changes
+server.setRequestHandler(SetLevelRequestSchema, async (request) => {
+  const level = request.params.level as LogLevel;
+  mcpLogger.setLevel(level);
+  mcpLogger.info('memoclaw', `Log level set to ${level}`);
+  return {};
+});
+
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+  mcpLogger.debug('tool', { event: 'call', tool: name, args });
   try {
-    return await handleToolCall(name, args as any);
+    const result = await handleToolCall(name, args as any);
+    mcpLogger.debug('tool', { event: 'success', tool: name });
+    return result;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    mcpLogger.error('tool', { event: 'error', tool: name, error: msg });
     return {
       content: [{ type: 'text', text: `Error: ${msg}` }],
       isError: true,

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,71 @@
+/**
+ * MCP Logging capability for MemoClaw.
+ *
+ * Provides structured logging that MCP clients can subscribe to.
+ * Supports syslog-level filtering via the logging/setLevel request.
+ *
+ * Levels (in order of severity):
+ *   debug < info < notice < warning < error < critical < alert < emergency
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+
+/** Syslog severity order (lower index = less severe) */
+const LEVEL_ORDER: LogLevel[] = ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+
+function levelIndex(level: LogLevel): number {
+  const idx = LEVEL_ORDER.indexOf(level);
+  return idx >= 0 ? idx : 0;
+}
+
+/**
+ * Logger that sends notifications to MCP clients via server.sendLoggingMessage.
+ * Respects the minimum level set by the client via logging/setLevel.
+ */
+export class McpLogger {
+  private minLevel: LogLevel = 'warning';
+  private server: Server | null = null;
+
+  /** Attach to a server instance. Call after server is created. */
+  attach(server: Server): void {
+    this.server = server;
+  }
+
+  /** Set the minimum log level. Messages below this level are suppressed. */
+  setLevel(level: LogLevel): void {
+    this.minLevel = level;
+  }
+
+  /** Get current minimum level */
+  getLevel(): LogLevel {
+    return this.minLevel;
+  }
+
+  /** Send a log message if it meets the minimum level threshold. */
+  async log(level: LogLevel, logger: string, data: unknown): Promise<void> {
+    if (levelIndex(level) < levelIndex(this.minLevel)) return;
+    if (!this.server) {
+      // Fallback to stderr if server not attached yet
+      console.error(`[${level}] [${logger}] ${typeof data === 'string' ? data : JSON.stringify(data)}`);
+      return;
+    }
+    try {
+      await this.server.sendLoggingMessage({ level, logger, data });
+    } catch {
+      // Don't let logging failures crash the server
+    }
+  }
+
+  // Convenience methods
+  debug(logger: string, data: unknown): Promise<void> { return this.log('debug', logger, data); }
+  info(logger: string, data: unknown): Promise<void> { return this.log('info', logger, data); }
+  notice(logger: string, data: unknown): Promise<void> { return this.log('notice', logger, data); }
+  warning(logger: string, data: unknown): Promise<void> { return this.log('warning', logger, data); }
+  error(logger: string, data: unknown): Promise<void> { return this.log('error', logger, data); }
+  critical(logger: string, data: unknown): Promise<void> { return this.log('critical', logger, data); }
+}
+
+/** Singleton logger instance */
+export const mcpLogger = new McpLogger();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -34,6 +34,7 @@ vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
   ListPromptsRequestSchema: 'ListPromptsRequestSchema',
   GetPromptRequestSchema: 'GetPromptRequestSchema',
   CompleteRequestSchema: 'CompleteRequestSchema',
+  SetLevelRequestSchema: 'SetLevelRequestSchema',
 }));
 
 vi.mock('@x402/core/client', () => ({
@@ -87,7 +88,7 @@ function mockFetchError(status: number, text: string) {
 
 describe('Tool Definitions', () => {
   it('registers both handlers', () => {
-    expect(mockSetRequestHandler).toHaveBeenCalledTimes(8);
+    expect(mockSetRequestHandler).toHaveBeenCalledTimes(9);
   });
 
   it('exposes all expected tools', async () => {


### PR DESCRIPTION
## Changes (Fixes #79)

Implements the MCP logging protocol so clients can subscribe to structured server logs.

### New file: `src/logging.ts`
- `McpLogger` class with syslog-level filtering (debug → emergency)
- Singleton `mcpLogger` instance used throughout the codebase
- Convenience methods: `.debug()`, `.info()`, `.warning()`, `.error()`, etc.
- Silent catch on logging failures — never crashes the server

### Integration points
- **`logging/setLevel` handler** — clients can set minimum log level
- **Tool calls** — logged at debug level (call + success), error level on failure
- **Resource reads** — logged at debug level, error on failure
- **API retries** — logged at debug level when retrying transient failures
- **x402 payments** — logged at info level when free tier is exhausted

### Default behavior
- Default level: `warning` (minimal noise out of the box)
- Clients can lower to `debug` for full request tracing
- All 203 tests pass ✅