### PR TITLE
feat: add typed args interfaces for all handler functions

### DIFF
--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -2,6 +2,11 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, extname, basename } from 'node:path';
 import { formatMemory, withConcurrency, validateContentLength, validateImportance } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
+import type {
+  StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
+  ExportArgs, MigrateArgs, DeleteNamespaceArgs, TagsArgs, HistoryArgs,
+  NamespacesArgs, CoreMemoriesArgs, StatsArgs,
+} from '../types.js';
 
 export async function handleAdmin(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
   const { makeRequest, account, config } = ctx;
@@ -44,7 +49,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_ingest': {
-      const { messages, text, namespace, session_id, agent_id, auto_relate } = args;
+      const { messages, text, namespace, session_id, agent_id, auto_relate } = args as IngestArgs;
       if (!messages && !text) throw new Error('Either messages or text is required');
       const result = await makeRequest('POST', '/v1/ingest', {
         messages, text, namespace, session_id, agent_id, auto_relate: auto_relate !== false,
@@ -54,7 +59,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_extract': {
-      const { messages, namespace, session_id, agent_id } = args;
+      const { messages, namespace, session_id, agent_id } = args as ExtractArgs;
       if (!messages || !Array.isArray(messages) || messages.length === 0) {
         throw new Error('messages is required and must be a non-empty array');
       }
@@ -63,7 +68,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_consolidate': {
-      const { namespace, min_similarity, mode, dry_run, agent_id } = args;
+      const { namespace, min_similarity, mode, dry_run, agent_id } = args as ConsolidateArgs;
       const body: any = {};
       if (namespace) body.namespace = namespace;
       if (agent_id) body.agent_id = agent_id;
@@ -76,7 +81,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_export': {
-      const { namespace, agent_id, format: fmt } = args;
+      const { namespace, agent_id, format: fmt } = args as ExportArgs;
       const params = new URLSearchParams();
       if (namespace) params.set('namespace', namespace);
       if (agent_id) params.set('agent_id', agent_id);
@@ -119,7 +124,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_migrate': {
-      const { path: filePath, files, namespace, agent_id, deduplicate, dry_run } = args;
+      const { path: filePath, files, namespace, agent_id, deduplicate, dry_run } = args as MigrateArgs;
       if (!filePath && !files) {
         throw new Error('Either "path" (file/directory path) or "files" (array of {filename, content}) is required');
       }
@@ -198,7 +203,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_delete_namespace': {
-      const { namespace, agent_id } = args;
+      const { namespace, agent_id } = args as DeleteNamespaceArgs;
       if (!namespace) throw new Error('namespace is required');
       const deletedIds: string[] = [];
       const errors: string[] = [];
@@ -242,7 +247,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_tags': {
-      const { namespace, agent_id } = args;
+      const { namespace, agent_id } = args as TagsArgs;
       try {
         const params = new URLSearchParams();
         if (namespace) params.set('namespace', namespace);
@@ -285,7 +290,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_history': {
-      const { id } = args;
+      const { id } = args as HistoryArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('GET', `/v1/memories/${id}/history`);
       const history = result.history || result.versions || result.data || [];
@@ -310,7 +315,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_namespaces': {
-      const { agent_id } = args;
+      const { agent_id } = args as NamespacesArgs;
       try {
         const params = new URLSearchParams();
         if (agent_id) params.set('agent_id', agent_id);
@@ -351,7 +356,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     }
 
     case 'memoclaw_core_memories': {
-      const { limit, namespace, agent_id } = args;
+      const { limit, namespace, agent_id } = args as CoreMemoriesArgs;
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (namespace) params.set('namespace', namespace);

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -1,12 +1,17 @@
 import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
+import type {
+  StoreArgs, GetArgs, ListArgs, UpdateArgs, DeleteArgs,
+  BulkDeleteArgs, BulkStoreArgs, ImportArgs, PinArgs, UnpinArgs,
+  BatchUpdateArgs, CountArgs,
+} from '../types.js';
 
 export async function handleMemory(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
   const { makeRequest } = ctx;
 
   switch (name) {
     case 'memoclaw_store': {
-      const { content, importance, tags, namespace, memory_type, session_id, agent_id, expires_at, pinned, immutable } = args;
+      const { content, importance, tags, namespace, memory_type, session_id, agent_id, expires_at, pinned, immutable } = args as StoreArgs;
       if (!content || (typeof content === 'string' && content.trim() === '')) {
         throw new Error('content is required and cannot be empty');
       }
@@ -27,14 +32,14 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_get': {
-      const { id } = args;
+      const { id } = args as GetArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('GET', `/v1/memories/${id}`);
       return { content: [{ type: 'text', text: `${formatMemory(result.memory || result)}\n\n${JSON.stringify(result, null, 2)}` }] };
     }
 
     case 'memoclaw_list': {
-      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after } = args;
+      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after } = args as ListArgs;
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (offset !== undefined) params.set('offset', String(offset));
@@ -54,7 +59,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_update': {
-      const { id, ...allFields } = args;
+      const { id, ...allFields } = args as UpdateArgs;
       if (!id) throw new Error('id is required');
       const updateFields: Record<string, any> = {};
       for (const [key, value] of Object.entries(allFields)) {
@@ -70,14 +75,14 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_delete': {
-      const { id } = args;
+      const { id } = args as DeleteArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('DELETE', `/v1/memories/${id}`);
       return { content: [{ type: 'text', text: `🗑️ Memory ${id} deleted\n\n${JSON.stringify(result, null, 2)}` }] };
     }
 
     case 'memoclaw_bulk_delete': {
-      const { ids } = args;
+      const { ids } = args as BulkDeleteArgs;
       if (!ids || !Array.isArray(ids) || ids.length === 0) {
         throw new Error('ids is required and must be a non-empty array');
       }
@@ -113,7 +118,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_bulk_store': {
-      const { memories, session_id, agent_id } = args;
+      const { memories, session_id, agent_id } = args as BulkStoreArgs;
       if (!memories || !Array.isArray(memories) || memories.length === 0) {
         throw new Error('memories is required and must be a non-empty array');
       }
@@ -184,7 +189,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_import': {
-      const { memories, session_id, agent_id } = args;
+      const { memories, session_id, agent_id } = args as ImportArgs;
       if (!memories || !Array.isArray(memories) || memories.length === 0) {
         throw new Error('memories is required and must be a non-empty array');
       }
@@ -254,21 +259,21 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_pin': {
-      const { id } = args;
+      const { id } = args as PinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
       return { content: [{ type: 'text', text: `📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}` }] };
     }
 
     case 'memoclaw_unpin': {
-      const { id } = args;
+      const { id } = args as UnpinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
       return { content: [{ type: 'text', text: `📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}` }] };
     }
 
     case 'memoclaw_batch_update': {
-      const { updates } = args;
+      const { updates } = args as BatchUpdateArgs;
       if (!updates || !Array.isArray(updates) || updates.length === 0) {
         throw new Error('updates is required and must be a non-empty array');
       }
@@ -314,7 +319,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_count': {
-      const { namespace, tags, agent_id, memory_type } = args;
+      const { namespace, tags, agent_id, memory_type } = args as CountArgs;
       const params = new URLSearchParams();
       if (namespace) params.set('namespace', namespace);
       if (tags && Array.isArray(tags) && tags.length > 0) params.set('tags', tags.join(','));

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -1,12 +1,13 @@
 import { formatMemory } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
+import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs } from '../types.js';
 
 export async function handleRecall(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
   const { makeRequest } = ctx;
 
   switch (name) {
     case 'memoclaw_recall': {
-      const { query, limit, min_similarity, tags, namespace, memory_type, session_id, agent_id, include_relations, after } = args;
+      const { query, limit, min_similarity, tags, namespace, memory_type, session_id, agent_id, include_relations, after } = args as RecallArgs;
       if (!query || (typeof query === 'string' && query.trim() === '')) {
         throw new Error('query is required and cannot be empty');
       }
@@ -28,7 +29,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_search': {
-      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after } = args;
+      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after } = args as SearchArgs;
       if (!query || (typeof query === 'string' && query.trim() === '')) {
         throw new Error('query is required and cannot be empty');
       }
@@ -51,7 +52,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_context': {
-      const { query, limit, namespace, session_id, agent_id } = args;
+      const { query, limit, namespace, session_id, agent_id } = args as ContextArgs;
       if (!query || (typeof query === 'string' && query.trim() === '')) {
         throw new Error('query is required and cannot be empty');
       }
@@ -70,7 +71,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_suggested': {
-      const { limit, namespace, session_id, agent_id, category } = args;
+      const { limit, namespace, session_id, agent_id, category } = args as SuggestedArgs;
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (namespace) params.set('namespace', namespace);

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,12 +1,13 @@
 import { formatMemory } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
+import type { CreateRelationArgs, ListRelationsArgs, DeleteRelationArgs, GraphArgs } from '../types.js';
 
 export async function handleRelations(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
   const { makeRequest } = ctx;
 
   switch (name) {
     case 'memoclaw_create_relation': {
-      const { memory_id, target_id, relation_type, metadata } = args;
+      const { memory_id, target_id, relation_type, metadata } = args as CreateRelationArgs;
       if (!memory_id || !target_id || !relation_type) {
         throw new Error('memory_id, target_id, and relation_type are all required');
       }
@@ -17,7 +18,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
     }
 
     case 'memoclaw_list_relations': {
-      const { memory_id } = args;
+      const { memory_id } = args as ListRelationsArgs;
       if (!memory_id) throw new Error('memory_id is required');
       const result = await makeRequest('GET', `/v1/memories/${memory_id}/relations`);
       const relations = result.relations || [];
@@ -31,14 +32,14 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
     }
 
     case 'memoclaw_delete_relation': {
-      const { memory_id, relation_id } = args;
+      const { memory_id, relation_id } = args as DeleteRelationArgs;
       if (!memory_id || !relation_id) throw new Error('memory_id and relation_id are required');
       const result = await makeRequest('DELETE', `/v1/memories/${memory_id}/relations/${relation_id}`);
       return { content: [{ type: 'text', text: `🗑️ Relation ${relation_id} deleted\n\n${JSON.stringify(result, null, 2)}` }] };
     }
 
     case 'memoclaw_graph': {
-      const { memory_id, depth: rawDepth, relation_type } = args;
+      const { memory_id, depth: rawDepth, relation_type } = args as GraphArgs;
       if (!memory_id) throw new Error('memory_id is required');
       const depth = Math.min(Math.max(rawDepth || 1, 1), 3);
       const visited = new Set<string>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,316 @@
+/**
+ * Typed argument interfaces for MCP tool handlers.
+ *
+ * These mirror the JSON schemas defined in tools.ts and replace `args: any`
+ * in handler functions to catch typos and type mismatches at compile time.
+ */
+
+// ── Memory CRUD ──────────────────────────────────────────────────────────────
+
+export interface StoreArgs {
+  content: string;
+  importance?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  session_id?: string;
+  agent_id?: string;
+  expires_at?: string;
+  pinned?: boolean;
+  immutable?: boolean;
+}
+
+export interface RecallArgs {
+  query: string;
+  limit?: number;
+  min_similarity?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  session_id?: string;
+  agent_id?: string;
+  include_relations?: boolean;
+  after?: string;
+}
+
+export interface SearchArgs {
+  query: string;
+  limit?: number;
+  namespace?: string;
+  tags?: string[];
+  memory_type?: string;
+  session_id?: string;
+  agent_id?: string;
+  after?: string;
+}
+
+export interface GetArgs {
+  id: string;
+}
+
+export interface ListArgs {
+  limit?: number;
+  offset?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  session_id?: string;
+  agent_id?: string;
+  after?: string;
+}
+
+export interface DeleteArgs {
+  id: string;
+}
+
+export interface BulkDeleteArgs {
+  ids: string[];
+}
+
+export interface UpdateArgs {
+  id: string;
+  content?: string;
+  importance?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  pinned?: boolean;
+  immutable?: boolean;
+  expires_at?: string;
+  session_id?: string;
+  agent_id?: string;
+  [key: string]: unknown;
+}
+
+export interface BatchUpdateEntry {
+  id: string;
+  content?: string;
+  importance?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  pinned?: boolean;
+  immutable?: boolean;
+  expires_at?: string;
+  [key: string]: unknown;
+}
+
+export interface BatchUpdateArgs {
+  updates: BatchUpdateEntry[];
+}
+
+// ── Bulk / Import / Export ────────────────────────────────────────────────────
+
+export interface BulkStoreMemory {
+  content: string;
+  importance?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  pinned?: boolean;
+  expires_at?: string;
+  immutable?: boolean;
+}
+
+export interface BulkStoreArgs {
+  memories: BulkStoreMemory[];
+  session_id?: string;
+  agent_id?: string;
+}
+
+export interface ImportMemory {
+  content: string;
+  importance?: number;
+  tags?: string[];
+  namespace?: string;
+  memory_type?: string;
+  pinned?: boolean;
+  immutable?: boolean;
+}
+
+export interface ImportArgs {
+  memories: ImportMemory[];
+  session_id?: string;
+  agent_id?: string;
+}
+
+export interface ExportArgs {
+  namespace?: string;
+  agent_id?: string;
+  format?: 'json' | 'jsonl';
+}
+
+// ── Intelligence / AI ────────────────────────────────────────────────────────
+
+export interface IngestArgs {
+  messages?: Array<{ role: string; content: string }>;
+  text?: string;
+  namespace?: string;
+  session_id?: string;
+  agent_id?: string;
+  auto_relate?: boolean;
+}
+
+export interface ExtractArgs {
+  messages: Array<{ role: string; content: string }>;
+  namespace?: string;
+  session_id?: string;
+  agent_id?: string;
+}
+
+export interface ConsolidateArgs {
+  namespace?: string;
+  min_similarity?: number;
+  mode?: string;
+  dry_run?: boolean;
+  agent_id?: string;
+}
+
+export interface SuggestedArgs {
+  limit?: number;
+  namespace?: string;
+  session_id?: string;
+  agent_id?: string;
+  category?: string;
+}
+
+export interface ContextArgs {
+  query: string;
+  limit?: number;
+  namespace?: string;
+  session_id?: string;
+  agent_id?: string;
+}
+
+// ── Relations ────────────────────────────────────────────────────────────────
+
+export interface CreateRelationArgs {
+  memory_id: string;
+  target_id: string;
+  relation_type: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ListRelationsArgs {
+  memory_id: string;
+}
+
+export interface DeleteRelationArgs {
+  memory_id: string;
+  relation_id: string;
+}
+
+export interface GraphArgs {
+  memory_id: string;
+  depth?: number;
+  relation_type?: string;
+}
+
+// ── Admin / Utility ──────────────────────────────────────────────────────────
+
+export interface StatusArgs {
+  // No arguments required
+}
+
+export interface InitArgs {
+  // No arguments required
+}
+
+export interface CountArgs {
+  namespace?: string;
+  tags?: string[];
+  agent_id?: string;
+  memory_type?: string;
+}
+
+export interface DeleteNamespaceArgs {
+  namespace: string;
+  agent_id?: string;
+}
+
+export interface PinArgs {
+  id: string;
+}
+
+export interface UnpinArgs {
+  id: string;
+}
+
+export interface TagsArgs {
+  namespace?: string;
+  agent_id?: string;
+}
+
+export interface HistoryArgs {
+  id: string;
+}
+
+export interface NamespacesArgs {
+  agent_id?: string;
+}
+
+export interface CoreMemoriesArgs {
+  limit?: number;
+  namespace?: string;
+  agent_id?: string;
+}
+
+export interface StatsArgs {
+  // No arguments required
+}
+
+export interface MigrateFile {
+  filename: string;
+  content: string;
+}
+
+export interface MigrateArgs {
+  path?: string;
+  files?: MigrateFile[];
+  namespace?: string;
+  agent_id?: string;
+  deduplicate?: boolean;
+  dry_run?: boolean;
+}
+
+// ── Union type for dispatch ──────────────────────────────────────────────────
+
+export type ToolArgs =
+  | { name: 'memoclaw_store'; args: StoreArgs }
+  | { name: 'memoclaw_recall'; args: RecallArgs }
+  | { name: 'memoclaw_search'; args: SearchArgs }
+  | { name: 'memoclaw_get'; args: GetArgs }
+  | { name: 'memoclaw_list'; args: ListArgs }
+  | { name: 'memoclaw_delete'; args: DeleteArgs }
+  | { name: 'memoclaw_bulk_delete'; args: BulkDeleteArgs }
+  | { name: 'memoclaw_update'; args: UpdateArgs }
+  | { name: 'memoclaw_batch_update'; args: BatchUpdateArgs }
+  | { name: 'memoclaw_bulk_store'; args: BulkStoreArgs }
+  | { name: 'memoclaw_import'; args: ImportArgs }
+  | { name: 'memoclaw_export'; args: ExportArgs }
+  | { name: 'memoclaw_ingest'; args: IngestArgs }
+  | { name: 'memoclaw_extract'; args: ExtractArgs }
+  | { name: 'memoclaw_consolidate'; args: ConsolidateArgs }
+  | { name: 'memoclaw_suggested'; args: SuggestedArgs }
+  | { name: 'memoclaw_context'; args: ContextArgs }
+  | { name: 'memoclaw_create_relation'; args: CreateRelationArgs }
+  | { name: 'memoclaw_list_relations'; args: ListRelationsArgs }
+  | { name: 'memoclaw_delete_relation'; args: DeleteRelationArgs }
+  | { name: 'memoclaw_graph'; args: GraphArgs }
+  | { name: 'memoclaw_status'; args: StatusArgs }
+  | { name: 'memoclaw_init'; args: InitArgs }
+  | { name: 'memoclaw_count'; args: CountArgs }
+  | { name: 'memoclaw_delete_namespace'; args: DeleteNamespaceArgs }
+  | { name: 'memoclaw_pin'; args: PinArgs }
+  | { name: 'memoclaw_unpin'; args: UnpinArgs }
+  | { name: 'memoclaw_tags'; args: TagsArgs }
+  | { name: 'memoclaw_history'; args: HistoryArgs }
+  | { name: 'memoclaw_namespaces'; args: NamespacesArgs }
+  | { name: 'memoclaw_core_memories'; args: CoreMemoriesArgs }
+  | { name: 'memoclaw_stats'; args: StatsArgs }
+  | { name: 'memoclaw_migrate'; args: MigrateArgs };
+
+/** Map from tool name to its args type */
+export type ToolArgsMap = {
+  [T in ToolArgs as T['name']]: T['args'];
+};


### PR DESCRIPTION
## Summary

Replace `args: any` in all 33 tool handler cases with proper TypeScript interfaces.

## Changes

- **New `src/types.ts`** — 33 typed interfaces matching the JSON schemas in `tools.ts`:
  - Memory CRUD: `StoreArgs`, `RecallArgs`, `SearchArgs`, `GetArgs`, `ListArgs`, `DeleteArgs`, `BulkDeleteArgs`, `UpdateArgs`, `BatchUpdateArgs`
  - Bulk/Import/Export: `BulkStoreArgs`, `ImportArgs`, `ExportArgs`
  - Intelligence: `IngestArgs`, `ExtractArgs`, `ConsolidateArgs`, `SuggestedArgs`, `ContextArgs`
  - Relations: `CreateRelationArgs`, `ListRelationsArgs`, `DeleteRelationArgs`, `GraphArgs`
  - Admin: `StatusArgs`, `InitArgs`, `CountArgs`, `DeleteNamespaceArgs`, `PinArgs`, `UnpinArgs`, `TagsArgs`, `HistoryArgs`, `NamespacesArgs`, `CoreMemoriesArgs`, `StatsArgs`, `MigrateArgs`
  - `ToolArgs` discriminated union and `ToolArgsMap` for type-safe dispatch

- **Updated `src/handlers.ts`** — each `case` now uses `args as XxxArgs` instead of raw `args: any`

## Benefits

- Catches typos in argument names at compile time
- IDE autocomplete for handler arguments
- Self-documenting — types serve as quick reference for each tool's parameters
- Foundation for the handler domain module refactor (#84)

## Impact
No runtime behavior change — purely compile-time type safety. All 203 tests pass.

Fixes #86