### PR TITLE
test: add unit tests for handler domain modules

### DIFF
--- a/tests/handlers/admin.test.ts
+++ b/tests/handlers/admin.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { handleAdmin } from '../../src/handlers/admin.js';
+import { createContext } from '../../src/handlers/types.js';
+import { mockApi, mockApiWithErrors, testConfig } from './helpers.js';
+
+function makeCtx(routes: Record<string, any> = {}) {
+  const api = mockApi(routes);
+  return { ctx: createContext(api as any, testConfig), api };
+}
+
+describe('handleAdmin', () => {
+  // ── status ───────────────────────────────────────────────────────────────
+  describe('memoclaw_status', () => {
+    it('returns wallet and free tier info', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/free-tier/status': { wallet: '0xABC', free_tier_remaining: 50, free_tier_total: 100 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_status', {});
+      expect(result!.content[0].text).toContain('0xABC');
+      expect(result!.content[0].text).toContain('50/100');
+    });
+  });
+
+  // ── init ─────────────────────────────────────────────────────────────────
+  describe('memoclaw_init', () => {
+    it('reports healthy when API reachable', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/free-tier/status': { free_tier_remaining: 80, free_tier_total: 100 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_init', {});
+      expect(result!.content[0].text).toContain('MemoClaw is ready');
+      expect(result!.content[0].text).toContain('API reachable');
+    });
+
+    it('reports unhealthy when API unreachable', async () => {
+      const api = mockApiWithErrors({}, {
+        'GET /v1/free-tier/status': new Error('Connection refused'),
+      });
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleAdmin(ctx, 'memoclaw_init', {});
+      expect(result!.content[0].text).toContain('needs configuration');
+      expect(result!.content[0].text).toContain('unreachable');
+    });
+
+    it('warns when free tier exhausted', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/free-tier/status': { free_tier_remaining: 0, free_tier_total: 100 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_init', {});
+      expect(result!.content[0].text).toContain('exhausted');
+    });
+  });
+
+  // ── ingest ───────────────────────────────────────────────────────────────
+  describe('memoclaw_ingest', () => {
+    it('ingests text', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/ingest': { memories_created: 3 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_ingest', { text: 'some text' });
+      expect(result!.content[0].text).toContain('3 memories created');
+    });
+
+    it('rejects missing messages and text', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_ingest', {}))
+        .rejects.toThrow('Either messages or text');
+    });
+  });
+
+  // ── extract ──────────────────────────────────────────────────────────────
+  describe('memoclaw_extract', () => {
+    it('extracts memories from messages', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/extract': { extracted: 2 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_extract', {
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      expect(result!.content[0].text).toContain('extracted');
+    });
+
+    it('rejects empty messages', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_extract', { messages: [] }))
+        .rejects.toThrow('non-empty array');
+    });
+  });
+
+  // ── consolidate ──────────────────────────────────────────────────────────
+  describe('memoclaw_consolidate', () => {
+    it('consolidates memories', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/consolidate': { merged: 5, removed: 3 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_consolidate', {});
+      expect(result!.content[0].text).toContain('Consolidation complete');
+    });
+
+    it('shows dry run prefix', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/consolidate': { would_merge: 5 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_consolidate', { dry_run: true });
+      expect(result!.content[0].text).toContain('dry run');
+    });
+  });
+
+  // ── export ───────────────────────────────────────────────────────────────
+  describe('memoclaw_export', () => {
+    it('exports memories', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/export': { memories: [{ id: '1', content: 'a' }, { id: '2', content: 'b' }] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_export', {});
+      expect(result!.content[0].text).toContain('Exported 2 memories');
+    });
+
+    it('falls back to pagination on 404', async () => {
+      const api = mockApiWithErrors(
+        { 'GET /v1/memories': { memories: [{ id: '1', content: 'a' }] } },
+        { 'GET /v1/export': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleAdmin(ctx, 'memoclaw_export', {});
+      expect(result!.content[0].text).toContain('Exported 1 memories');
+    });
+  });
+
+  // ── delete_namespace ─────────────────────────────────────────────────────
+  describe('memoclaw_delete_namespace', () => {
+    it('deletes all memories in namespace', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories': { memories: [{ id: '1' }, { id: '2' }] },
+        'DELETE /v1/memories/': { deleted: true },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_delete_namespace', { namespace: 'test' });
+      expect(result!.content[0].text).toContain('2 memories deleted');
+    });
+
+    it('rejects missing namespace', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_delete_namespace', {}))
+        .rejects.toThrow('namespace is required');
+    });
+  });
+
+  // ── tags ─────────────────────────────────────────────────────────────────
+  describe('memoclaw_tags', () => {
+    it('returns tags from dedicated endpoint', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/tags': { tags: [{ tag: 'work', count: 5 }, { tag: 'personal', count: 3 }] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_tags', {});
+      expect(result!.content[0].text).toContain('2 tags');
+      expect(result!.content[0].text).toContain('work');
+    });
+
+    it('handles empty tags', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/tags': { tags: [] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_tags', {});
+      expect(result!.content[0].text).toContain('No tags found');
+    });
+  });
+
+  // ── history ──────────────────────────────────────────────────────────────
+  describe('memoclaw_history', () => {
+    it('returns version history', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': { history: [{ content: 'v1' }, { content: 'v2' }] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_history', { id: '1' });
+      expect(result!.content[0].text).toContain('2 versions');
+    });
+
+    it('rejects missing id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_history', {}))
+        .rejects.toThrow('id is required');
+    });
+  });
+
+  // ── namespaces ───────────────────────────────────────────────────────────
+  describe('memoclaw_namespaces', () => {
+    it('returns namespaces from API', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/namespaces': { namespaces: [{ namespace: 'work', count: 10 }, { namespace: 'personal', count: 5 }] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_namespaces', {});
+      expect(result!.content[0].text).toContain('2 namespaces');
+    });
+  });
+
+  // ── core_memories ────────────────────────────────────────────────────────
+  describe('memoclaw_core_memories', () => {
+    it('returns core memories', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/core-memories': { memories: [{ id: '1', content: 'important', importance: 1.0 }] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_core_memories', {});
+      expect(result!.content[0].text).toContain('1 core memories');
+    });
+
+    it('handles empty core memories', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/core-memories': { memories: [] },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_core_memories', {});
+      expect(result!.content[0].text).toContain('No core memories found');
+    });
+  });
+
+  // ── stats ────────────────────────────────────────────────────────────────
+  describe('memoclaw_stats', () => {
+    it('returns memory stats', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/stats': { total_memories: 100, pinned_count: 5, avg_importance: 0.73 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_stats', {});
+      expect(result!.content[0].text).toContain('100');
+      expect(result!.content[0].text).toContain('0.73');
+    });
+  });
+
+  // ── migrate ──────────────────────────────────────────────────────────────
+  describe('memoclaw_migrate', () => {
+    it('migrates files via API', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/migrate': { memories_created: 3, duplicates_skipped: 1 },
+      });
+      const result = await handleAdmin(ctx, 'memoclaw_migrate', {
+        files: [{ filename: 'test.md', content: '# Hello' }],
+      });
+      expect(result!.content[0].text).toContain('Migration complete');
+      expect(result!.content[0].text).toContain('3');
+    });
+
+    it('rejects missing path and files', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_migrate', {}))
+        .rejects.toThrow('Either "path"');
+    });
+
+    it('handles dry run with ingest fallback', async () => {
+      const api = mockApiWithErrors(
+        {},
+        { 'POST /v1/migrate': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleAdmin(ctx, 'memoclaw_migrate', {
+        files: [{ filename: 'test.md', content: '# Hello' }],
+        dry_run: true,
+      });
+      expect(result!.content[0].text).toContain('dry run');
+      expect(result!.content[0].text).toContain('test.md');
+    });
+  });
+
+  it('returns null for unknown tools', async () => {
+    const { ctx } = makeCtx();
+    expect(await handleAdmin(ctx, 'memoclaw_store', {})).toBeNull();
+  });
+});

--- a/tests/handlers/helpers.ts
+++ b/tests/handlers/helpers.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest';
+import type { Config } from '../../src/config.js';
+
+/** Create a mock API client with configurable route responses */
+export function mockApi(routes: Record<string, any> = {}) {
+  const makeRequest = vi.fn().mockImplementation(async (method: string, path: string, body?: any) => {
+    const key = `${method} ${path}`;
+    // Exact match first
+    if (routes[key] !== undefined) {
+      return typeof routes[key] === 'function' ? routes[key](path, body) : routes[key];
+    }
+    // Prefix match
+    for (const [pattern, value] of Object.entries(routes)) {
+      const [pMethod, pPath] = pattern.split(' ');
+      if (method === pMethod && pPath && path.startsWith(pPath)) {
+        return typeof value === 'function' ? value(path, body) : value;
+      }
+    }
+    return {};
+  });
+  return { makeRequest, account: { address: '0xTestWallet' } };
+}
+
+/** Create a mock API that throws on specific routes */
+export function mockApiWithErrors(routes: Record<string, any> = {}, errorRoutes: Record<string, Error> = {}) {
+  const makeRequest = vi.fn().mockImplementation(async (method: string, path: string, body?: any) => {
+    const key = `${method} ${path}`;
+    // Check error routes first
+    for (const [pattern, error] of Object.entries(errorRoutes)) {
+      const [pMethod, pPath] = pattern.split(' ');
+      if (method === pMethod && pPath && (path === pPath || path.startsWith(pPath))) {
+        throw error;
+      }
+    }
+    // Normal routes
+    if (routes[key] !== undefined) {
+      return typeof routes[key] === 'function' ? routes[key](path, body) : routes[key];
+    }
+    for (const [pattern, value] of Object.entries(routes)) {
+      const [pMethod, pPath] = pattern.split(' ');
+      if (method === pMethod && pPath && path.startsWith(pPath)) {
+        return typeof value === 'function' ? value(path, body) : value;
+      }
+    }
+    return {};
+  });
+  return { makeRequest, account: { address: '0xTestWallet' } };
+}
+
+export const testConfig: Config = {
+  privateKey: '0x' + '1'.repeat(64),
+  apiUrl: 'https://test.memoclaw.com',
+  configSource: 'test',
+  timeout: 5000,
+  maxRetries: 0,
+};

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleMemory } from '../../src/handlers/memory.js';
+import { createContext } from '../../src/handlers/types.js';
+import { mockApi, mockApiWithErrors, testConfig } from './helpers.js';
+
+function makeCtx(routes: Record<string, any> = {}) {
+  const api = mockApi(routes);
+  return { ctx: createContext(api as any, testConfig), api };
+}
+
+describe('handleMemory', () => {
+  // ── store ────────────────────────────────────────────────────────────────
+  describe('memoclaw_store', () => {
+    it('stores a memory successfully', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/store': { memory: { id: '1', content: 'hello' } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_store', { content: 'hello' });
+      expect(result).not.toBeNull();
+      expect(result!.content[0].text).toContain('Memory stored');
+    });
+
+    it('rejects empty content', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_store', { content: '' }))
+        .rejects.toThrow('content is required');
+    });
+
+    it('rejects whitespace-only content', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_store', { content: '   ' }))
+        .rejects.toThrow('content is required');
+    });
+
+    it('validates importance range', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_store', { content: 'hi', importance: 2 }))
+        .rejects.toThrow();
+    });
+
+    it('passes all optional fields', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/store': { memory: { id: '1', content: 'test' } },
+      });
+      await handleMemory(ctx, 'memoclaw_store', {
+        content: 'test', importance: 0.8, tags: ['a'], namespace: 'ns',
+        memory_type: 'fact', session_id: 's1', agent_id: 'a1',
+        expires_at: '2026-12-31', pinned: true, immutable: true,
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.importance).toBe(0.8);
+      expect(body.tags).toEqual(['a']);
+      expect(body.pinned).toBe(true);
+      expect(body.immutable).toBe(true);
+    });
+  });
+
+  // ── get ──────────────────────────────────────────────────────────────────
+  describe('memoclaw_get', () => {
+    it('returns a formatted memory', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': { memory: { id: '1', content: 'hello' } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_get', { id: '1' });
+      expect(result!.content[0].text).toContain('hello');
+    });
+
+    it('rejects missing id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_get', {}))
+        .rejects.toThrow('id is required');
+    });
+  });
+
+  // ── list ─────────────────────────────────────────────────────────────────
+  describe('memoclaw_list', () => {
+    it('lists memories with total count', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories': { memories: [{ id: '1', content: 'a' }], total: 5 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_list', {});
+      expect(result!.content[0].text).toContain('1 of 5');
+    });
+
+    it('handles empty list', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories': { memories: [], total: 0 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_list', {});
+      expect(result!.content[0].text).toContain('0 of 0');
+    });
+  });
+
+  // ── update ───────────────────────────────────────────────────────────────
+  describe('memoclaw_update', () => {
+    it('updates content', async () => {
+      const { ctx } = makeCtx({
+        'PATCH /v1/memories/': { memory: { id: '1', content: 'updated' } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_update', { id: '1', content: 'updated' });
+      expect(result!.content[0].text).toContain('updated');
+    });
+
+    it('rejects missing id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_update', { content: 'x' }))
+        .rejects.toThrow('id is required');
+    });
+
+    it('rejects no valid update fields', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_update', { id: '1', bad_field: 'x' }))
+        .rejects.toThrow('No valid update fields');
+    });
+  });
+
+  // ── delete ───────────────────────────────────────────────────────────────
+  describe('memoclaw_delete', () => {
+    it('deletes a memory', async () => {
+      const { ctx } = makeCtx({
+        'DELETE /v1/memories/': { deleted: true },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_delete', { id: '1' });
+      expect(result!.content[0].text).toContain('deleted');
+    });
+  });
+
+  // ── bulk_delete ──────────────────────────────────────────────────────────
+  describe('memoclaw_bulk_delete', () => {
+    it('deletes via batch endpoint', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/bulk-delete': { deleted: 3 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_bulk_delete', { ids: ['1', '2', '3'] });
+      expect(result!.content[0].text).toContain('3 succeeded');
+    });
+
+    it('rejects empty ids array', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_bulk_delete', { ids: [] }))
+        .rejects.toThrow('non-empty array');
+    });
+
+    it('rejects >100 ids', async () => {
+      const { ctx } = makeCtx();
+      const ids = Array.from({ length: 101 }, (_, i) => String(i));
+      await expect(handleMemory(ctx, 'memoclaw_bulk_delete', { ids }))
+        .rejects.toThrow('Maximum 100');
+    });
+
+    it('falls back to one-by-one on error', async () => {
+      const api = mockApiWithErrors(
+        { 'DELETE /v1/memories/': { deleted: true } },
+        { 'POST /v1/memories/bulk-delete': new Error('server error') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleMemory(ctx, 'memoclaw_bulk_delete', { ids: ['1', '2'] });
+      expect(result!.content[0].text).toContain('2 succeeded');
+    });
+  });
+
+  // ── bulk_store ───────────────────────────────────────────────────────────
+  describe('memoclaw_bulk_store', () => {
+    it('stores via batch endpoint', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/store/batch': { memories: [{ id: '1', content: 'a' }, { id: '2', content: 'b' }], failed: [] },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_bulk_store', {
+        memories: [{ content: 'a' }, { content: 'b' }],
+      });
+      expect(result!.content[0].text).toContain('2 stored');
+      expect(result!.content[0].text).toContain('0 failed');
+    });
+
+    it('rejects empty memories', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_bulk_store', { memories: [] }))
+        .rejects.toThrow('non-empty array');
+    });
+
+    it('validates individual memory content', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_bulk_store', {
+        memories: [{ content: 'ok' }, { content: '' }],
+      })).rejects.toThrow('index 1');
+    });
+
+    it('falls back to one-by-one on 404', async () => {
+      const api = mockApiWithErrors(
+        { 'POST /v1/store': { memory: { id: '1', content: 'ok' } } },
+        { 'POST /v1/store/batch': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleMemory(ctx, 'memoclaw_bulk_store', {
+        memories: [{ content: 'a' }, { content: 'b' }],
+      });
+      expect(result!.content[0].text).toContain('2 stored');
+    });
+
+    it('does not leak extra fields to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/store/batch': { memories: [{ id: '1', content: 'ok' }], failed: [] },
+      });
+      await handleMemory(ctx, 'memoclaw_bulk_store', {
+        memories: [{ content: 'ok', extra_bad_field: 'should not appear' }],
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.memories[0].content).toBe('ok');
+      expect(body.memories[0].extra_bad_field).toBeUndefined();
+    });
+  });
+
+  // ── import ───────────────────────────────────────────────────────────────
+  describe('memoclaw_import', () => {
+    it('imports via batch endpoint', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/store/batch': { memories: [{ id: '1', content: 'a' }], failed: [] },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_import', {
+        memories: [{ content: 'a' }],
+      });
+      expect(result!.content[0].text).toContain('1 stored');
+    });
+
+    it('rejects empty memories', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_import', { memories: [] }))
+        .rejects.toThrow('non-empty array');
+    });
+  });
+
+  // ── pin / unpin ──────────────────────────────────────────────────────────
+  describe('memoclaw_pin / memoclaw_unpin', () => {
+    it('pins a memory', async () => {
+      const { ctx } = makeCtx({
+        'PATCH /v1/memories/': { memory: { id: '1', content: 'x', pinned: true } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_pin', { id: '1' });
+      expect(result!.content[0].text).toContain('pinned');
+    });
+
+    it('unpins a memory', async () => {
+      const { ctx } = makeCtx({
+        'PATCH /v1/memories/': { memory: { id: '1', content: 'x', pinned: false } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_unpin', { id: '1' });
+      expect(result!.content[0].text).toContain('unpinned');
+    });
+  });
+
+  // ── batch_update ─────────────────────────────────────────────────────────
+  describe('memoclaw_batch_update', () => {
+    it('updates via batch endpoint', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/batch-update': { updated: 2, memories: [{ id: '1' }, { id: '2' }] },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_batch_update', {
+        updates: [{ id: '1', content: 'new1' }, { id: '2', content: 'new2' }],
+      });
+      expect(result!.content[0].text).toContain('2 memories updated');
+    });
+
+    it('falls back to one-by-one on 404', async () => {
+      const api = mockApiWithErrors(
+        { 'PATCH /v1/memories/': { memory: { id: '1', content: 'updated' } } },
+        { 'POST /v1/memories/batch-update': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleMemory(ctx, 'memoclaw_batch_update', {
+        updates: [{ id: '1', content: 'new' }],
+      });
+      expect(result!.content[0].text).toContain('1 updated');
+    });
+
+    it('rejects empty updates', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_batch_update', { updates: [] }))
+        .rejects.toThrow('non-empty array');
+    });
+
+    it('rejects update missing id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_batch_update', {
+        updates: [{ content: 'no id' }],
+      })).rejects.toThrow('missing "id"');
+    });
+  });
+
+  // ── count ────────────────────────────────────────────────────────────────
+  describe('memoclaw_count', () => {
+    it('returns count from dedicated endpoint', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/count': { count: 42 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_count', {});
+      expect(result!.content[0].text).toContain('42');
+    });
+
+    it('falls back to list total on 404', async () => {
+      const api = mockApiWithErrors(
+        { 'GET /v1/memories': { memories: [], total: 15 } },
+        { 'GET /v1/memories/count': new Error('Not found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      const result = await handleMemory(ctx, 'memoclaw_count', {});
+      expect(result!.content[0].text).toContain('15');
+    });
+  });
+
+  // ── unknown tool returns null ────────────────────────────────────────────
+  it('returns null for unknown tools', async () => {
+    const { ctx } = makeCtx();
+    const result = await handleMemory(ctx, 'memoclaw_unknown_tool', {});
+    expect(result).toBeNull();
+  });
+});

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { handleRecall } from '../../src/handlers/recall.js';
+import { createContext } from '../../src/handlers/types.js';
+import { mockApi, testConfig } from './helpers.js';
+
+function makeCtx(routes: Record<string, any> = {}) {
+  const api = mockApi(routes);
+  return { ctx: createContext(api as any, testConfig), api };
+}
+
+describe('handleRecall', () => {
+  describe('memoclaw_recall', () => {
+    it('returns formatted memories', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [{ id: '1', content: 'match', similarity: 0.95 }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'test' });
+      expect(result!.content[0].text).toContain('Found 1 memories');
+      expect(result!.content[0].text).toContain('match');
+    });
+
+    it('returns message when no memories found', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'nothing' });
+      expect(result!.content[0].text).toContain('No memories found');
+    });
+
+    it('rejects empty query', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRecall(ctx, 'memoclaw_recall', { query: '' }))
+        .rejects.toThrow('query is required');
+    });
+
+    it('passes filters to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', {
+        query: 'test', tags: ['a'], memory_type: 'fact', namespace: 'ns',
+        limit: 5, min_similarity: 0.8,
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters.tags).toEqual(['a']);
+      expect(body.filters.memory_type).toBe('fact');
+      expect(body.namespace).toBe('ns');
+      expect(body.limit).toBe(5);
+    });
+  });
+
+  describe('memoclaw_search', () => {
+    it('returns text search results', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/search': { memories: [{ id: '1', content: 'found' }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_search', { query: 'found' });
+      expect(result!.content[0].text).toContain('Found 1 memories');
+    });
+
+    it('rejects empty query', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRecall(ctx, 'memoclaw_search', { query: '  ' }))
+        .rejects.toThrow('query is required');
+    });
+  });
+
+  describe('memoclaw_context', () => {
+    it('returns context memories', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/context': { memories: [{ id: '1', content: 'ctx' }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_context', { query: 'topic' });
+      expect(result!.content[0].text).toContain('Context for "topic"');
+    });
+
+    it('handles empty context', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/context': { memories: [] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_context', { query: 'nothing' });
+      expect(result!.content[0].text).toContain('No relevant context');
+    });
+  });
+
+  describe('memoclaw_suggested', () => {
+    it('returns suggestions', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/suggested': { suggestions: [{ id: '1', content: 'suggestion' }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_suggested', {});
+      expect(result!.content[0].text).toContain('1 suggestions');
+    });
+
+    it('handles empty suggestions', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/suggested': { suggestions: [] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_suggested', {});
+      expect(result!.content[0].text).toContain('No suggestions found');
+    });
+
+    it('includes category in output', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/suggested': { suggestions: [{ id: '1', content: 'x' }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_suggested', { category: 'personal' });
+      expect(result!.content[0].text).toContain('(personal)');
+    });
+  });
+
+  it('returns null for unknown tools', async () => {
+    const { ctx } = makeCtx();
+    expect(await handleRecall(ctx, 'memoclaw_store', {})).toBeNull();
+  });
+});

--- a/tests/handlers/relations.test.ts
+++ b/tests/handlers/relations.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { handleRelations } from '../../src/handlers/relations.js';
+import { createContext } from '../../src/handlers/types.js';
+import { mockApi, testConfig } from './helpers.js';
+
+function makeCtx(routes: Record<string, any> = {}) {
+  const api = mockApi(routes);
+  return { ctx: createContext(api as any, testConfig), api };
+}
+
+describe('handleRelations', () => {
+  describe('memoclaw_create_relation', () => {
+    it('creates a relation', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/memories/': { relation: { id: 'r1' } },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_create_relation', {
+        memory_id: 'm1', target_id: 'm2', relation_type: 'related_to',
+      });
+      expect(result!.content[0].text).toContain('Relation created');
+      expect(result!.content[0].text).toContain('related_to');
+    });
+
+    it('rejects missing fields', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_create_relation', {
+        memory_id: 'm1', target_id: 'm2',
+      })).rejects.toThrow('required');
+    });
+  });
+
+  describe('memoclaw_list_relations', () => {
+    it('lists relations', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': { relations: [{ id: 'r1', source_id: 'm1', relation_type: 'ref', target_id: 'm2' }] },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_list_relations', { memory_id: 'm1' });
+      expect(result!.content[0].text).toContain('Relations for m1');
+    });
+
+    it('handles no relations', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': { relations: [] },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_list_relations', { memory_id: 'm1' });
+      expect(result!.content[0].text).toContain('No relations found');
+    });
+
+    it('rejects missing memory_id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_list_relations', {}))
+        .rejects.toThrow('memory_id is required');
+    });
+  });
+
+  describe('memoclaw_delete_relation', () => {
+    it('deletes a relation', async () => {
+      const { ctx } = makeCtx({
+        'DELETE /v1/memories/': { deleted: true },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_delete_relation', {
+        memory_id: 'm1', relation_id: 'r1',
+      });
+      expect(result!.content[0].text).toContain('Relation r1 deleted');
+    });
+
+    it('rejects missing ids', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_delete_relation', { memory_id: 'm1' }))
+        .rejects.toThrow('required');
+    });
+  });
+
+  describe('memoclaw_graph', () => {
+    it('builds a graph from a root memory', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': (path: string) => {
+          if (path.includes('/relations')) {
+            return { relations: [{ source_id: 'm1', target_id: 'm2', relation_type: 'ref' }] };
+          }
+          const id = path.split('/').pop();
+          return { memory: { id, content: `content-${id}` } };
+        },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_graph', {
+        memory_id: 'm1', depth: 1,
+      });
+      expect(result!.content[0].text).toContain('Graph from m1');
+      expect(result!.content[0].text).toContain('2 nodes');
+      expect(result!.content[0].text).toContain('1 edges');
+    });
+
+    it('rejects missing memory_id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_graph', {}))
+        .rejects.toThrow('memory_id is required');
+    });
+
+    it('clamps depth to 1-3', async () => {
+      const { ctx } = makeCtx({
+        'GET /v1/memories/': (path: string) => {
+          if (path.includes('/relations')) return { relations: [] };
+          return { memory: { id: 'm1', content: 'test' } };
+        },
+      });
+      const result = await handleRelations(ctx, 'memoclaw_graph', {
+        memory_id: 'm1', depth: 10,
+      });
+      expect(result!.content[0].text).toContain('depth 3');
+    });
+  });
+
+  it('returns null for unknown tools', async () => {
+    const { ctx } = makeCtx();
+    expect(await handleRelations(ctx, 'memoclaw_recall', {})).toBeNull();
+  });
+});


### PR DESCRIPTION
Add focused unit tests for each handler module:
- `tests/handlers/memory.test.ts` (33 tests) — store, get, list, update, delete, bulk ops, import, pin/unpin, batch update, count
- `tests/handlers/recall.test.ts` (12 tests) — recall, search, context, suggested  
- `tests/handlers/relations.test.ts` (11 tests) — create, list, delete relations, graph traversal
- `tests/handlers/admin.test.ts` (26 tests) — status, init, ingest, extract, consolidate, export, migrate, namespaces, tags, history, stats

Tests mock `makeRequest` directly without MCP server overhead, covering:
- Success paths
- Input validation and error messages
- Fallback logic (batch→one-by-one, export→pagination)
- Edge cases (empty results, exhausted free tier, depth clamping)

Total test count: 274 → 356

Closes #87