### PR TITLE
fix: move tool title to top-level property per MCP spec 2025-06-18

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,7 +2,10 @@
  * MCP tool definitions for MemoClaw.
  * Each tool maps to an API endpoint or composite operation.
  *
- * Annotations follow the MCP spec (2025-03-26+):
+ * Per MCP spec 2025-06-18:
+ *   title — human-readable display name (top-level tool property)
+ *
+ * Annotations (tool behavior hints):
  *   readOnlyHint  — true if the tool does not modify server-side state
  *   destructiveHint — true if the tool may permanently delete data
  *   idempotentHint — true if calling multiple times with the same args has no extra effect
@@ -28,8 +31,8 @@ export const TOOLS = [
       'Use tags and namespace to organize memories. Set importance (0-1) to influence recall ranking. ' +
       'Use memory_type to control how the memory decays over time. Pin important memories to prevent decay. ' +
       'Returns the created memory object with its ID. Free tier: 100 calls/wallet.',
+    title: 'Store memory',
     annotations: {
-      title: 'Store memory',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -60,8 +63,8 @@ export const TOOLS = [
       'Returns results ranked by similarity score (0-1). Use min_similarity=0.3+ to filter low-quality matches. ' +
       'Set include_relations=true to also fetch related memories via the knowledge graph. ' +
       '💡 TIP: If you know the memory ID, use memoclaw_get (faster). For exact keyword matching, use memoclaw_search.',
+    title: 'Semantic recall',
     annotations: {
-      title: 'Semantic recall',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -85,8 +88,8 @@ export const TOOLS = [
       '🔎 KEYWORD SEARCH: Find memories containing exact keywords or phrases. ' +
       'Unlike memoclaw_recall (semantic search), this does exact string matching. ' +
       'For finding similar meanings, use memoclaw_recall instead.',
+    title: 'Keyword search',
     annotations: {
-      title: 'Keyword search',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -106,8 +109,8 @@ export const TOOLS = [
     name: 'memoclaw_get',
     description:
       'Retrieve a single memory by its exact ID. Use this when you already know the memory ID.',
+    title: 'Get memory',
     annotations: {
-      title: 'Get memory',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -127,8 +130,8 @@ export const TOOLS = [
       '📋 LIST: Browse all memories chronologically (newest first). ' +
       'Supports filtering by tags, namespace, memory_type, session_id, agent_id. ' +
       '💡 TIP: For semantic search, use memoclaw_recall. For keywords, use memoclaw_search.',
+    title: 'List memories',
     annotations: {
-      title: 'List memories',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -146,8 +149,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_delete',
     description: 'Permanently delete a single memory by its ID. This cannot be undone.',
+    title: 'Delete memory',
     annotations: {
-      title: 'Delete memory',
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
@@ -164,8 +167,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_bulk_delete',
     description: 'Delete multiple memories at once by their IDs. Max 100 IDs per call.',
+    title: 'Bulk delete memories',
     annotations: {
-      title: 'Bulk delete memories',
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
@@ -184,8 +187,8 @@ export const TOOLS = [
     description:
       'Update an existing memory by its ID. Only provided fields are changed. ' +
       'If you update content, the semantic embedding is automatically regenerated.',
+    title: 'Update memory',
     annotations: {
-      title: 'Update memory',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
@@ -211,8 +214,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_status',
     description: 'Check your wallet\'s free tier usage. Shows remaining API calls out of 100.',
+    title: 'Free tier status',
     annotations: {
-      title: 'Free tier status',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -225,8 +228,8 @@ export const TOOLS = [
     description:
       'Bulk-ingest a conversation or raw text. The server extracts facts, deduplicates, ' +
       'and optionally creates relations. Provide either messages OR text, not both.',
+    title: 'Ingest conversation',
     annotations: {
-      title: 'Ingest conversation',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -249,8 +252,8 @@ export const TOOLS = [
     description:
       'Extract structured facts from a conversation via LLM, without auto-relating them. ' +
       'Use this when you want to review extracted facts before relating them.',
+    title: 'Extract facts',
     annotations: {
-      title: 'Extract facts',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -271,8 +274,8 @@ export const TOOLS = [
     name: 'memoclaw_consolidate',
     description:
       'Merge similar/duplicate memories by clustering. Use dry_run=true first to preview.',
+    title: 'Consolidate memories',
     annotations: {
-      title: 'Consolidate memories',
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: false,
@@ -293,8 +296,8 @@ export const TOOLS = [
     name: 'memoclaw_suggested',
     description:
       'Get proactive memory suggestions: stale, fresh, hot, or decaying memories.',
+    title: 'Suggested memories',
     annotations: {
-      title: 'Suggested memories',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -315,8 +318,8 @@ export const TOOLS = [
     name: 'memoclaw_create_relation',
     description:
       'Create a directed relationship between two memories for the knowledge graph.',
+    title: 'Create relation',
     annotations: {
-      title: 'Create relation',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -336,8 +339,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_list_relations',
     description: 'List all relationships for a specific memory (incoming and outgoing).',
+    title: 'List relations',
     annotations: {
-      title: 'List relations',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -354,8 +357,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_delete_relation',
     description: 'Delete a specific relationship between memories.',
+    title: 'Delete relation',
     annotations: {
-      title: 'Delete relation',
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
@@ -373,8 +376,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_export',
     description: 'Export all memories as JSON. Useful for backup, migration, or analysis.',
+    title: 'Export memories',
     annotations: {
-      title: 'Export memories',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -393,8 +396,8 @@ export const TOOLS = [
     name: 'memoclaw_import',
     description:
       'Import memories from a JSON array. Each object must have a "content" field. Max 100 per call.',
+    title: 'Import memories',
     annotations: {
-      title: 'Import memories',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -431,8 +434,8 @@ export const TOOLS = [
     description:
       'Store multiple memories in a single call. Max 100 per call. ' +
       'Each memory can have its own tags, namespace, importance, etc.',
+    title: 'Bulk store memories',
     annotations: {
-      title: 'Bulk store memories',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -467,8 +470,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_count',
     description: 'Get a count of memories, optionally filtered. Faster than memoclaw_list when you only need the total.',
+    title: 'Count memories',
     annotations: {
-      title: 'Count memories',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -489,8 +492,8 @@ export const TOOLS = [
     description:
       'Delete ALL memories in a namespace. Destructive and cannot be undone. ' +
       'Use memoclaw_count first to check how many will be affected.',
+    title: 'Delete namespace',
     annotations: {
-      title: 'Delete namespace',
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: true,
@@ -510,8 +513,8 @@ export const TOOLS = [
     description:
       'Check if MemoClaw is properly configured. Returns config status, wallet address, and free tier remaining. ' +
       'Call this FIRST to verify the connection works.',
+    title: 'Check configuration',
     annotations: {
-      title: 'Check configuration',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -525,8 +528,8 @@ export const TOOLS = [
       'Migrate local markdown memory files into MemoClaw. ' +
       'Accepts EITHER a directory/file path OR an array of file objects. ' +
       'Supports .md and .txt files. Recursively scans directories.',
+    title: 'Migrate files',
     annotations: {
-      title: 'Migrate files',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
@@ -559,8 +562,8 @@ export const TOOLS = [
     name: 'memoclaw_graph',
     description:
       'Traverse the memory graph from a starting memory up to a specified depth.',
+    title: 'Traverse graph',
     annotations: {
-      title: 'Traverse graph',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -579,8 +582,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_pin',
     description: '📌 Pin a memory to prevent decay. Shortcut for memoclaw_update with pinned=true.',
+    title: 'Pin memory',
     annotations: {
-      title: 'Pin memory',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
@@ -595,8 +598,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_unpin',
     description: '📌 Unpin a memory, re-enabling decay. Shortcut for memoclaw_update with pinned=false.',
+    title: 'Unpin memory',
     annotations: {
-      title: 'Unpin memory',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
@@ -611,8 +614,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_tags',
     description: '🏷️ List all unique tags with counts. Sorted by usage (most used first).',
+    title: 'List tags',
     annotations: {
-      title: 'List tags',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -629,8 +632,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_history',
     description: '📜 View the edit history of a specific memory.',
+    title: 'Memory history',
     annotations: {
-      title: 'Memory history',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -645,8 +648,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_namespaces',
     description: 'List all namespaces that contain memories with counts.',
+    title: 'List namespaces',
     annotations: {
-      title: 'List namespaces',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -662,8 +665,8 @@ export const TOOLS = [
     description:
       '🧠 CONTEXT: Get contextually relevant memories using GPT-4o-mini analysis. ' +
       'Costs $0.01 per call.',
+    title: 'Get context',
     annotations: {
-      title: 'Get context',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -684,8 +687,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_batch_update',
     description: 'Update multiple memories in a single call. Max 50 updates. Costs $0.005 per call.',
+    title: 'Batch update memories',
     annotations: {
-      title: 'Batch update memories',
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
@@ -721,8 +724,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_core_memories',
     description: '⭐ Get your most important memories — high importance, frequently accessed, or pinned. FREE.',
+    title: 'Core memories',
     annotations: {
-      title: 'Core memories',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
@@ -740,8 +743,8 @@ export const TOOLS = [
   {
     name: 'memoclaw_stats',
     description: '📊 Get memory usage statistics. FREE.',
+    title: 'Memory statistics',
     annotations: {
-      title: 'Memory statistics',
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -117,11 +117,12 @@ describe('Tool Definitions', () => {
     expect(result.tools).toHaveLength(33);
   });
 
-  it('every tool has annotations with all required hints', async () => {
+  it('every tool has a title and annotations with all required hints', async () => {
     const result = await listToolsHandler();
     for (const tool of result.tools) {
+      // MCP 2025-06-18: title is a top-level tool property, not inside annotations
+      expect(typeof tool.title, `${tool.name} missing title`).toBe('string');
       expect(tool.annotations, `${tool.name} missing annotations`).toBeDefined();
-      expect(typeof tool.annotations.title).toBe('string');
       expect(typeof tool.annotations.readOnlyHint).toBe('boolean');
       expect(typeof tool.annotations.destructiveHint).toBe('boolean');
       expect(typeof tool.annotations.idempotentHint).toBe('boolean');


### PR DESCRIPTION
## What

Moves `title` from inside `annotations` to a top-level tool property for all 33 tools, per the MCP specification 2025-06-18.

## Why

The MCP spec defines `title` as a top-level property on tool definitions (alongside `name`, `description`, `inputSchema`, `outputSchema`, `annotations`). Having it inside `annotations` is non-compliant and may cause MCP clients to not display tool titles correctly.

**Before:**
```ts
{
  name: 'memoclaw_store',
  description: '...',
  annotations: {
    title: 'Store memory',  // ❌ wrong placement
    readOnlyHint: false,
  },
}
```

**After:**
```ts
{
  name: 'memoclaw_store',
  description: '...',
  title: 'Store memory',  // ✅ top-level per spec
  annotations: {
    readOnlyHint: false,
  },
}
```

## Changes
- `src/tools.ts`: Move `title` out of `annotations` to top-level for all 33 tools
- `tests/tools.test.ts`: Update test to verify `title` at top level

## Testing
All 356 tests pass.