### PR TITLE
feat: add content annotations (audience, priority) to tool results

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -68,6 +68,43 @@ export function validateContentLength(content: string, label = 'content'): void 
   }
 }
 
+// ---------------------------------------------------------------------------
+// Content annotation helpers (MCP 2025-06-18)
+// ---------------------------------------------------------------------------
+
+import type { ContentAnnotations, TextContentItem } from './handlers/types.js';
+
+/**
+ * Build a text content item intended for both user and assistant display.
+ * Used for formatted memory output, success messages, etc.
+ */
+export function userAndAssistantText(text: string, priority = 0.8): TextContentItem {
+  return { type: 'text', text, annotations: { audience: ['user', 'assistant'], priority } };
+}
+
+/**
+ * Build a text content item intended only for the assistant (LLM).
+ * Used for raw JSON dumps that are useful for programmatic processing.
+ */
+export function assistantText(text: string, priority = 0.3): TextContentItem {
+  return { type: 'text', text, annotations: { audience: ['assistant'], priority } };
+}
+
+/**
+ * Build a text content item intended only for the user.
+ * Used for error messages and status information.
+ */
+export function userText(text: string, priority = 0.5): TextContentItem {
+  return { type: 'text', text, annotations: { audience: ['user'], priority } };
+}
+
+/**
+ * Build a text content item for error messages (user-facing, high priority).
+ */
+export function errorText(text: string): TextContentItem {
+  return { type: 'text', text, annotations: { audience: ['user'], priority: 1.0 } };
+}
+
 /** Allowed fields for the update endpoint */
 export const UPDATE_FIELDS = new Set([
   'content', 'importance', 'memory_type', 'namespace',

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, extname, basename } from 'node:path';
-import { formatMemory, withConcurrency, validateContentLength, validateImportance } from '../format.js';
+import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
@@ -17,7 +17,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const remaining = data.free_tier_remaining ?? 'unknown';
       const total = data.free_tier_total ?? 100;
       const pct = typeof remaining === 'number' ? Math.round((remaining / total) * 100) : '?';
-      return { content: [{ type: 'text', text: `Wallet: ${data.wallet || account.address}\nFree tier: ${remaining}/${total} calls remaining (${pct}%)` }] };
+      return { content: [userText(`Wallet: ${data.wallet || account.address}\nFree tier: ${remaining}/${total} calls remaining (${pct}%)`, 0.5)] };
     }
 
     case 'memoclaw_init': {
@@ -45,7 +45,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         checks.push(`   4. Restart the MCP server`);
       }
       const status = healthy ? '🟢 MemoClaw is ready!' : '🔴 MemoClaw needs configuration';
-      return { content: [{ type: 'text', text: `${status}\n\n${checks.join('\n')}` }] };
+      return { content: [userText(`${status}\n\n${checks.join('\n')}`, healthy ? 0.5 : 1.0)] };
     }
 
     case 'memoclaw_ingest': {
@@ -55,7 +55,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         messages, text, namespace, session_id, agent_id, auto_relate: auto_relate !== false,
       });
       const count = result.memories_created ?? result.count ?? '?';
-      return { content: [{ type: 'text', text: `📥 Ingested: ${count} memories created\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`📥 Ingested: ${count} memories created`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_extract': {
@@ -64,7 +67,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         throw new Error('messages is required and must be a non-empty array');
       }
       const result = await makeRequest('POST', '/v1/memories/extract', { messages, namespace, session_id, agent_id });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      return { content: [assistantText(JSON.stringify(result, null, 2))] };
     }
 
     case 'memoclaw_consolidate': {
@@ -77,7 +80,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       if (dry_run !== undefined) body.dry_run = dry_run;
       const result = await makeRequest('POST', '/v1/memories/consolidate', body);
       const prefix = dry_run ? '🔍 Consolidation preview (dry run)' : '✅ Consolidation complete';
-      return { content: [{ type: 'text', text: `${prefix}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(prefix),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_export': {
@@ -94,7 +100,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const output = fmt === 'jsonl'
           ? list.map((m: any) => JSON.stringify(m)).join('\n')
           : JSON.stringify(list, null, 2);
-        return { content: [{ type: 'text', text: `📦 Exported ${list.length} memories\n\n${output}` }] };
+        return { content: [
+          userAndAssistantText(`📦 Exported ${list.length} memories`),
+          assistantText(output),
+        ] };
       } catch (exportErr: any) {
         // Only fall back to pagination if /v1/export is not found (404)
         if (!exportErr.message?.includes('404') && !exportErr.message?.includes('Not Found')) {
@@ -119,7 +128,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const output = fmt === 'jsonl'
           ? allMemories.map((m: any) => JSON.stringify(m)).join('\n')
           : JSON.stringify(allMemories, null, 2);
-        return { content: [{ type: 'text', text: `📦 Exported ${allMemories.length} memories\n\n${output}` }] };
+        return { content: [
+          userAndAssistantText(`📦 Exported ${allMemories.length} memories`),
+          assistantText(output),
+        ] };
       }
     }
 
@@ -158,7 +170,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       }
 
       if (fileList.length === 0) {
-        return { content: [{ type: 'text', text: '⚠️ No .md or .txt files found at the given path.' }] };
+        return { content: [userText('⚠️ No .md or .txt files found at the given path.', 0.7)] };
       }
 
       const body: any = {
@@ -174,11 +186,14 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const prefix = dry_run ? '🔍 Migration preview (dry run)' : '✅ Migration complete';
         const created = result.memories_created ?? result.count ?? '?';
         const skipped = result.duplicates_skipped ?? 0;
-        return { content: [{ type: 'text', text: `${prefix}\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${created}\n🔄 Duplicates skipped: ${skipped}\n\n${JSON.stringify(result, null, 2)}` }] };
+        return { content: [
+          userAndAssistantText(`${prefix}\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${created}\n🔄 Duplicates skipped: ${skipped}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ] };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
           if (dry_run) {
-            return { content: [{ type: 'text', text: `🔍 Migration preview (dry run — /v1/migrate not available, would use ingest fallback)\n\n📁 ${fileList.length} files would be ingested:\n${fileList.map(f => `  • ${f.filename} (${f.content.length} chars)`).join('\n')}` }] };
+            return { content: [userAndAssistantText(`🔍 Migration preview (dry run — /v1/migrate not available, would use ingest fallback)\n\n📁 ${fileList.length} files would be ingested:\n${fileList.map(f => `  • ${f.filename} (${f.content.length} chars)`).join('\n')}`)] };
           }
           let totalCreated = 0;
           const errors: string[] = [];
@@ -196,7 +211,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
           }
           let text = `✅ Migration complete (via ingest fallback)\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${totalCreated}`;
           if (errors.length > 0) text += `\n\n❌ Errors:\n${errors.join('\n')}`;
-          return { content: [{ type: 'text', text }] };
+          return { content: [userAndAssistantText(text)] };
         }
         throw err;
       }
@@ -243,7 +258,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
       let text = `🗑️ Namespace "${namespace}": ${deletedIds.length} memories deleted`;
       if (errors.length > 0) text += `, ${errors.length} failed\n\nErrors:\n${errors.slice(0, 10).join('\n')}`;
-      return { content: [{ type: 'text', text }] };
+      return { content: [userAndAssistantText(text)] };
     }
 
     case 'memoclaw_tags': {
@@ -256,11 +271,11 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const result = await makeRequest('GET', `/v1/tags${qs ? '?' + qs : ''}`);
         if (result.tags) {
           const tags = result.tags;
-          if (tags.length === 0) return { content: [{ type: 'text', text: 'No tags found across memories.' }] };
+          if (tags.length === 0) return { content: [userText('No tags found across memories.', 0.3)] };
           const lines = tags.map((t: any) =>
             typeof t === 'string' ? `  • ${t}` : `  • ${t.tag || t.name}: ${t.count} memories`
           );
-          return { content: [{ type: 'text', text: `🏷️ ${tags.length} tags:\n\n${lines.join('\n')}` }] };
+          return { content: [userText(`🏷️ ${tags.length} tags:\n\n${lines.join('\n')}`, 0.5)] };
         }
       } catch { /* fall through to client-side */ }
 
@@ -283,10 +298,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (memories.length < pageSize) break;
         offset += pageSize;
       }
-      if (tagCounts.size === 0) return { content: [{ type: 'text', text: 'No tags found across memories.' }] };
+      if (tagCounts.size === 0) return { content: [userText('No tags found across memories.', 0.3)] };
       const sorted = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
       const lines = sorted.map(([tag, count]) => `  • ${tag}: ${count} memories`);
-      return { content: [{ type: 'text', text: `🏷️ ${sorted.length} tags:\n\n${lines.join('\n')}` }] };
+      return { content: [userText(`🏷️ ${sorted.length} tags:\n\n${lines.join('\n')}`, 0.5)] };
     }
 
     case 'memoclaw_history': {
@@ -295,7 +310,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const result = await makeRequest('GET', `/v1/memories/${id}/history`);
       const history = result.history || result.versions || result.data || [];
       if (history.length === 0) {
-        return { content: [{ type: 'text', text: `No edit history found for memory ${id}.` }] };
+        return { content: [userText(`No edit history found for memory ${id}.`, 0.3)] };
       }
       const formatted = history.map((entry: any, i: number) => {
         const parts = [`Version ${i + 1}`];
@@ -311,7 +326,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (entry.changed_fields) parts.push(`  changed: ${Array.isArray(entry.changed_fields) ? entry.changed_fields.join(', ') : entry.changed_fields}`);
         return parts.join('\n');
       }).join('\n\n');
-      return { content: [{ type: 'text', text: `📜 History for memory ${id} (${history.length} versions):\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`📜 History for memory ${id} (${history.length} versions):\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_namespaces': {
@@ -323,11 +341,11 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const result = await makeRequest('GET', `/v1/namespaces${qs ? '?' + qs : ''}`);
         if (result.namespaces) {
           const namespaces = result.namespaces;
-          if (namespaces.length === 0) return { content: [{ type: 'text', text: 'No memories found — no namespaces to list.' }] };
+          if (namespaces.length === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)] };
           const lines = namespaces.map((n: any) =>
             typeof n === 'string' ? `  • ${n}` : `  • ${n.namespace || n.name || '(default)'}: ${n.count} memories`
           );
-          return { content: [{ type: 'text', text: `📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}` }] };
+          return { content: [userText(`📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}`, 0.5)] };
         }
       } catch { /* fall through */ }
 
@@ -349,10 +367,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (memories.length < pageSize) break;
         offset += pageSize;
       }
-      if (nsCounts.size === 0) return { content: [{ type: 'text', text: 'No memories found — no namespaces to list.' }] };
+      if (nsCounts.size === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)] };
       const sorted = [...nsCounts.entries()].sort((a, b) => b[1] - a[1]);
       const lines = sorted.map(([ns, count]) => `  • ${ns}: ${count} memories`);
-      return { content: [{ type: 'text', text: `📁 ${sorted.length} namespaces:\n\n${lines.join('\n')}` }] };
+      return { content: [userText(`📁 ${sorted.length} namespaces:\n\n${lines.join('\n')}`, 0.5)] };
     }
 
     case 'memoclaw_core_memories': {
@@ -365,10 +383,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const result = await makeRequest('GET', `/v1/core-memories${qs ? '?' + qs : ''}`);
       const memories = result.memories || result.core_memories || result.data || [];
       if (memories.length === 0) {
-        return { content: [{ type: 'text', text: 'No core memories found. Store important memories with high importance scores or pin them.' }] };
+        return { content: [userText('No core memories found. Store important memories with high importance scores or pin them.', 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [{ type: 'text', text: `⭐ ${memories.length} core memories:\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`⭐ ${memories.length} core memories:\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_stats': {
@@ -389,7 +410,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         lines.push('\nBy namespace:');
         for (const n of result.by_namespace) lines.push(`  • ${n.namespace || '(default)'}: ${n.count}`);
       }
-      return { content: [{ type: 'text', text: `📊 Memory Stats\n\n${lines.join('\n')}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userText(`📊 Memory Stats\n\n${lines.join('\n')}`, 0.5),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     default:

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -1,4 +1,4 @@
-import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS } from '../format.js';
+import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StoreArgs, GetArgs, ListArgs, UpdateArgs, DeleteArgs,
@@ -28,14 +28,20 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (pinned !== undefined) body.pinned = pinned;
       if (immutable !== undefined) body.immutable = immutable;
       const result = await makeRequest('POST', '/v1/store', body);
-      return { content: [{ type: 'text', text: `✅ Memory stored\n${formatMemory(result.memory || result)}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`✅ Memory stored\n${formatMemory(result.memory || result)}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_get': {
       const { id } = args as GetArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('GET', `/v1/memories/${id}`);
-      return { content: [{ type: 'text', text: `${formatMemory(result.memory || result)}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(formatMemory(result.memory || result)),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_list': {
@@ -55,7 +61,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       const formatted = memories.length > 0
         ? '\n\n' + memories.map((m: any) => formatMemory(m)).join('\n\n')
         : '';
-      return { content: [{ type: 'text', text: `Showing ${memories.length} of ${total} memories${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`Showing ${memories.length} of ${total} memories${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_update': {
@@ -71,14 +80,20 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (typeof updateFields.content === 'string') validateContentLength(updateFields.content);
       validateImportance(updateFields.importance);
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, updateFields);
-      return { content: [{ type: 'text', text: `✅ Memory ${id} updated\n${formatMemory(result.memory || result)}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`✅ Memory ${id} updated\n${formatMemory(result.memory || result)}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_delete': {
       const { id } = args as DeleteArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('DELETE', `/v1/memories/${id}`);
-      return { content: [{ type: 'text', text: `🗑️ Memory ${id} deleted\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`🗑️ Memory ${id} deleted`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_bulk_delete': {
@@ -114,7 +129,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
       let text = `🗑️ Bulk delete: ${succeeded} succeeded, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [{ type: 'text', text }] };
+      return { content: [userAndAssistantText(text)] };
     }
 
     case 'memoclaw_bulk_store': {
@@ -154,7 +169,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
           text += `\n\nErrors:\n${errors.join('\n')}`;
         }
-        return { content: [{ type: 'text', text }] };
+        return { content: [userAndAssistantText(text)] };
       } catch (batchErr: any) {
         // Fall back to one-by-one if batch endpoint is unavailable (404)
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
@@ -185,7 +200,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       let text = `✅ Bulk store: ${succeeded.length} stored, ${failed.length} failed`;
       if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [{ type: 'text', text }] };
+      return { content: [userAndAssistantText(text)] };
     }
 
     case 'memoclaw_import': {
@@ -225,7 +240,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
           text += `\n\nErrors:\n${errors.join('\n')}`;
         }
-        return { content: [{ type: 'text', text }] };
+        return { content: [userAndAssistantText(text)] };
       } catch (batchErr: any) {
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
           throw batchErr;
@@ -255,21 +270,21 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         .filter(Boolean);
       let text = `📥 Import: ${succeeded} stored, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [{ type: 'text', text }] };
+      return { content: [userAndAssistantText(text)] };
     }
 
     case 'memoclaw_pin': {
       const { id } = args as PinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
-      return { content: [{ type: 'text', text: `📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}` }] };
+      return { content: [userAndAssistantText(`📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}`)] };
     }
 
     case 'memoclaw_unpin': {
       const { id } = args as UnpinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
-      return { content: [{ type: 'text', text: `📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}` }] };
+      return { content: [userAndAssistantText(`📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}`)] };
     }
 
     case 'memoclaw_batch_update': {
@@ -288,7 +303,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         const memories = result.memories || [];
         let text = `✅ Batch update: ${updated} memories updated`;
         if (memories.length > 0) text += `\n\n${memories.map((m: any) => formatMemory(m)).join('\n\n')}`;
-        return { content: [{ type: 'text', text: `${text}\n\n${JSON.stringify(result, null, 2)}` }] };
+        return { content: [
+          userAndAssistantText(text),
+          assistantText(JSON.stringify(result, null, 2)),
+        ] };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
           const results = await withConcurrency(
@@ -312,7 +330,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           let text = `✅ Batch update: ${succeeded.length} updated, ${failed.length} failed`;
           if (memories.length > 0) text += `\n\n${memories.map((m: any) => formatMemory(m)).join('\n\n')}`;
           if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-          return { content: [{ type: 'text', text }] };
+          return { content: [userAndAssistantText(text)] };
         }
         throw err;
       }
@@ -362,7 +380,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
       const filters = [namespace && `namespace=${namespace}`, memory_type && `type=${memory_type}`, agent_id && `agent=${agent_id}`, tags?.length && `tags=${tags.join(',')}`].filter(Boolean);
       const filterStr = filters.length > 0 ? ` (${filters.join(', ')})` : '';
-      return { content: [{ type: 'text', text: `📊 Total memories${filterStr}: ${total}` }] };
+      return { content: [userText(`📊 Total memories${filterStr}: ${total}`, 0.5)] };
     }
 
     default:

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -1,4 +1,4 @@
-import { formatMemory } from '../format.js';
+import { formatMemory, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs } from '../types.js';
 
@@ -22,10 +22,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       });
       const memories = result.memories || [];
       if (memories.length === 0) {
-        return { content: [{ type: 'text', text: `No memories found for query: "${query}"` }] };
+        return { content: [userText(`No memories found for query: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [{ type: 'text', text: `Found ${memories.length} memories:\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`Found ${memories.length} memories:\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_search': {
@@ -45,10 +48,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('GET', `/v1/memories/search?${params}`);
       const memories = result.memories || result.data || [];
       if (memories.length === 0) {
-        return { content: [{ type: 'text', text: `No memories found containing: "${query}"` }] };
+        return { content: [userText(`No memories found containing: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [{ type: 'text', text: `Found ${memories.length} memories containing "${query}":\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`Found ${memories.length} memories containing "${query}":\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_context': {
@@ -64,10 +70,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('POST', '/v1/context', body);
       const memories = result.memories || result.context || [];
       if (memories.length === 0) {
-        return { content: [{ type: 'text', text: `No relevant context found for: "${query}"` }] };
+        return { content: [userText(`No relevant context found for: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [{ type: 'text', text: `🧠 Context for "${query}" (${memories.length} memories):\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`🧠 Context for "${query}" (${memories.length} memories):\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_suggested': {
@@ -82,10 +91,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('GET', `/v1/suggested${qs ? '?' + qs : ''}`);
       const suggestions = result.suggestions || result.memories || [];
       if (suggestions.length === 0) {
-        return { content: [{ type: 'text', text: `No suggestions found${category ? ` for category "${category}"` : ''}.` }] };
+        return { content: [userText(`No suggestions found${category ? ` for category "${category}"` : ''}.`, 0.3)] };
       }
       const formatted = suggestions.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [{ type: 'text', text: `💡 ${suggestions.length} suggestions${category ? ` (${category})` : ''}:\n\n${formatted}\n\n---\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`💡 ${suggestions.length} suggestions${category ? ` (${category})` : ''}:\n\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     default:

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,4 +1,4 @@
-import { formatMemory } from '../format.js';
+import { formatMemory, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { CreateRelationArgs, ListRelationsArgs, DeleteRelationArgs, GraphArgs } from '../types.js';
 
@@ -14,7 +14,10 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const body: any = { target_id, relation_type };
       if (metadata) body.metadata = metadata;
       const result = await makeRequest('POST', `/v1/memories/${memory_id}/relations`, body);
-      return { content: [{ type: 'text', text: `🔗 Relation created: ${memory_id} —[${relation_type}]→ ${target_id}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`🔗 Relation created: ${memory_id} —[${relation_type}]→ ${target_id}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_list_relations': {
@@ -23,19 +26,25 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const result = await makeRequest('GET', `/v1/memories/${memory_id}/relations`);
       const relations = result.relations || [];
       if (relations.length === 0) {
-        return { content: [{ type: 'text', text: `No relations found for memory ${memory_id}.` }] };
+        return { content: [userText(`No relations found for memory ${memory_id}.`, 0.3)] };
       }
       const formatted = relations.map((r: any) =>
         `🔗 ${r.id || '?'}: ${r.source_id || memory_id} —[${r.relation_type}]→ ${r.target_id}`
       ).join('\n');
-      return { content: [{ type: 'text', text: `Relations for ${memory_id}:\n${formatted}\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`Relations for ${memory_id}:\n${formatted}`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_delete_relation': {
       const { memory_id, relation_id } = args as DeleteRelationArgs;
       if (!memory_id || !relation_id) throw new Error('memory_id and relation_id are required');
       const result = await makeRequest('DELETE', `/v1/memories/${memory_id}/relations/${relation_id}`);
-      return { content: [{ type: 'text', text: `🗑️ Relation ${relation_id} deleted\n\n${JSON.stringify(result, null, 2)}` }] };
+      return { content: [
+        userAndAssistantText(`🗑️ Relation ${relation_id} deleted`),
+        assistantText(JSON.stringify(result, null, 2)),
+      ] };
     }
 
     case 'memoclaw_graph': {
@@ -76,7 +85,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
       const nodesFmt = nodes.map((n: any) => formatMemory(n)).join('\n\n');
       const edgesFmt = edges.map((r: any) => `  ${r.source_id} —[${r.relation_type}]→ ${r.target_id}`).join('\n');
-      return { content: [{ type: 'text', text: `🕸️ Graph from ${memory_id} (depth ${depth}):\n\n${nodes.length} nodes:\n${nodesFmt}\n\n${edges.length} edges:\n${edgesFmt || '  (none)'}` }] };
+      return { content: [userAndAssistantText(`🕸️ Graph from ${memory_id} (depth ${depth}):\n\n${nodes.length} nodes:\n${nodesFmt}\n\n${edges.length} edges:\n${edgesFmt || '  (none)'}`)] };
     }
 
     default:

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -1,7 +1,23 @@
 import type { ApiClient } from '../api.js';
 import type { Config } from '../config.js';
 
-export type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+/**
+ * MCP content annotations per spec 2025-06-18.
+ * - audience: who should see this content ('user', 'assistant', or both)
+ * - priority: importance hint (0.0 = low, 1.0 = high)
+ */
+export interface ContentAnnotations {
+  audience?: Array<'user' | 'assistant'>;
+  priority?: number;
+}
+
+export interface TextContentItem {
+  type: 'text';
+  text: string;
+  annotations?: ContentAnnotations;
+}
+
+export type ToolResult = { content: TextContentItem[]; isError?: boolean };
 
 export type ToolHandler = (name: string, args: any) => Promise<ToolResult>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const msg = error instanceof Error ? error.message : String(error);
     mcpLogger.error('tool', { event: 'error', tool: name, error: msg });
     return {
-      content: [{ type: 'text', text: `Error: ${msg}` }],
+      content: [{ type: 'text', text: `Error: ${msg}`, annotations: { audience: ['user'], priority: 1.0 } }],
       isError: true,
     };
   }

--- a/tests/annotations.test.ts
+++ b/tests/annotations.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleMemory } from '../src/handlers/memory.js';
+import { handleRecall } from '../src/handlers/recall.js';
+import { handleAdmin } from '../src/handlers/admin.js';
+import { handleRelations } from '../src/handlers/relations.js';
+import type { HandlerContext } from '../src/handlers/types.js';
+
+/**
+ * Tests for MCP 2025-06-18 content annotations.
+ * Verifies that tool results include proper audience and priority hints.
+ */
+
+function createMockContext(mockResponse: any = {}): HandlerContext {
+  return {
+    api: {} as any,
+    config: { apiUrl: 'https://api.memoclaw.com', privateKey: '0x1234', configSource: 'env', timeout: 30000, maxRetries: 3, allowedOrigins: 'any' } as any,
+    makeRequest: async () => mockResponse,
+    account: { address: '0xTestWallet' } as any,
+  };
+}
+
+describe('Content Annotations', () => {
+  describe('Memory handlers', () => {
+    it('memoclaw_store returns annotated content with separated JSON', async () => {
+      const ctx = createMockContext({ memory: { id: '1', content: 'test' } });
+      const result = await handleMemory(ctx, 'memoclaw_store', { content: 'test' });
+      expect(result).not.toBeNull();
+      expect(result!.content.length).toBe(2);
+
+      // Formatted text: user + assistant audience
+      const formatted = result!.content[0];
+      expect(formatted.annotations?.audience).toContain('user');
+      expect(formatted.annotations?.audience).toContain('assistant');
+      expect(formatted.annotations?.priority).toBe(0.8);
+
+      // Raw JSON: assistant only
+      const raw = result!.content[1];
+      expect(raw.annotations?.audience).toEqual(['assistant']);
+      expect(raw.annotations?.priority).toBe(0.3);
+      expect(raw.text).toContain('{');
+    });
+
+    it('memoclaw_get returns annotated content', async () => {
+      const ctx = createMockContext({ memory: { id: '1', content: 'hello' } });
+      const result = await handleMemory(ctx, 'memoclaw_get', { id: '1' });
+      expect(result!.content.length).toBe(2);
+      expect(result!.content[0].annotations?.audience).toContain('user');
+      expect(result!.content[1].annotations?.audience).toEqual(['assistant']);
+    });
+
+    it('memoclaw_delete returns user+assistant annotation', async () => {
+      const ctx = createMockContext({ deleted: true });
+      const result = await handleMemory(ctx, 'memoclaw_delete', { id: '1' });
+      expect(result!.content[0].annotations?.audience).toContain('user');
+      expect(result!.content[0].annotations?.audience).toContain('assistant');
+    });
+
+    it('memoclaw_count returns user-only annotation', async () => {
+      const ctx = createMockContext({ count: 42 });
+      const result = await handleMemory(ctx, 'memoclaw_count', {});
+      expect(result!.content.length).toBe(1);
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.5);
+    });
+
+    it('memoclaw_pin returns user+assistant annotation', async () => {
+      const ctx = createMockContext({ memory: { id: '1', content: 'pinned', pinned: true } });
+      const result = await handleMemory(ctx, 'memoclaw_pin', { id: '1' });
+      expect(result!.content[0].annotations?.audience).toContain('user');
+      expect(result!.content[0].annotations?.audience).toContain('assistant');
+    });
+  });
+
+  describe('Recall handlers', () => {
+    it('memoclaw_recall returns annotated results with separated JSON', async () => {
+      const ctx = createMockContext({ memories: [{ id: '1', content: 'test', similarity: 0.9 }] });
+      const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'test' });
+      expect(result!.content.length).toBe(2);
+      expect(result!.content[0].annotations?.audience).toContain('user');
+      expect(result!.content[0].annotations?.audience).toContain('assistant');
+      expect(result!.content[0].annotations?.priority).toBe(0.8);
+      expect(result!.content[1].annotations?.audience).toEqual(['assistant']);
+    });
+
+    it('memoclaw_recall empty results returns user-only low priority', async () => {
+      const ctx = createMockContext({ memories: [] });
+      const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'nothing' });
+      expect(result!.content.length).toBe(1);
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.3);
+    });
+
+    it('memoclaw_search empty results returns user-only low priority', async () => {
+      const ctx = createMockContext({ memories: [] });
+      const result = await handleRecall(ctx, 'memoclaw_search', { query: 'nothing' });
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.3);
+    });
+  });
+
+  describe('Admin handlers', () => {
+    it('memoclaw_status returns user-only annotation', async () => {
+      const ctx = createMockContext({ free_tier_remaining: 50, free_tier_total: 100, wallet: '0xTest' });
+      const result = await handleAdmin(ctx, 'memoclaw_status', {});
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.5);
+    });
+
+    it('memoclaw_stats returns user text + assistant JSON', async () => {
+      const ctx = createMockContext({ total_memories: 100 });
+      const result = await handleAdmin(ctx, 'memoclaw_stats', {});
+      expect(result!.content.length).toBe(2);
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.5);
+      expect(result!.content[1].annotations?.audience).toEqual(['assistant']);
+    });
+
+    it('memoclaw_extract returns assistant-only JSON', async () => {
+      const ctx = createMockContext({ memories: [] });
+      const result = await handleAdmin(ctx, 'memoclaw_extract', { messages: [{ role: 'user', content: 'hi' }] });
+      expect(result!.content[0].annotations?.audience).toEqual(['assistant']);
+    });
+
+    it('memoclaw_tags empty returns user-only low priority', async () => {
+      const ctx = createMockContext({ tags: [] });
+      const result = await handleAdmin(ctx, 'memoclaw_tags', {});
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.3);
+    });
+
+    it('memoclaw_namespaces with data returns user-only', async () => {
+      const ctx = createMockContext({ namespaces: [{ namespace: 'default', count: 10 }] });
+      const result = await handleAdmin(ctx, 'memoclaw_namespaces', {});
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.5);
+    });
+  });
+
+  describe('Relations handlers', () => {
+    it('memoclaw_create_relation returns annotated content', async () => {
+      const ctx = createMockContext({ id: 'r1' });
+      const result = await handleRelations(ctx, 'memoclaw_create_relation', {
+        memory_id: 'm1', target_id: 'm2', relation_type: 'related_to',
+      });
+      expect(result!.content.length).toBe(2);
+      expect(result!.content[0].annotations?.audience).toContain('user');
+      expect(result!.content[1].annotations?.audience).toEqual(['assistant']);
+    });
+
+    it('memoclaw_list_relations empty returns user-only low priority', async () => {
+      const ctx = createMockContext({ relations: [] });
+      const result = await handleRelations(ctx, 'memoclaw_list_relations', { memory_id: 'm1' });
+      expect(result!.content[0].annotations?.audience).toEqual(['user']);
+      expect(result!.content[0].annotations?.priority).toBe(0.3);
+    });
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -953,7 +953,9 @@ describe('Tool Handlers', () => {
     const result = await callToolHandler({
       params: { name: 'memoclaw_export', arguments: { format: 'jsonl' } },
     });
-    const lines = result.content[0].text.split('\n').filter((l: string) => l.startsWith('{'));
+    // Raw data is in the assistant-only content item (content[1])
+    const dataText = result.content[1]?.text ?? result.content[0].text;
+    const lines = dataText.split('\n').filter((l: string) => l.startsWith('{'));
     expect(lines.length).toBe(2);
   });
 


### PR DESCRIPTION
## Summary

Implements MCP 2025-06-18 content annotations on all tool result items, enabling MCP clients to decide what to show users vs what to feed to the LLM.

### Annotation strategy

| Content type | Audience | Priority |
|---|---|---|
| Formatted memory text (success messages) | `['user', 'assistant']` | 0.8 |
| Raw JSON dumps | `['assistant']` | 0.3 |
| Error messages | `['user']` | 1.0 |
| Status/stats/metadata | `['user']` | 0.5 |
| Empty results | `['user']` | 0.3 |

### Changes

- **`src/handlers/types.ts`**: Extended `ToolResult` type with `ContentAnnotations` and `TextContentItem` interfaces
- **`src/format.ts`**: Added annotation helper functions (`userAndAssistantText`, `assistantText`, `userText`, `errorText`)
- **`src/handlers/memory.ts`**: Annotated all 12 memory tool returns, separated raw JSON into assistant-only items
- **`src/handlers/recall.ts`**: Annotated all 4 recall tool returns
- **`src/handlers/relations.ts`**: Annotated all 4 relation tool returns
- **`src/handlers/admin.ts`**: Annotated all admin tool returns (status, init, ingest, extract, consolidate, export, migrate, tags, history, namespaces, core memories, stats)
- **`src/index.ts`**: Added error annotation to the global error handler
- **`tests/annotations.test.ts`**: 15 new tests verifying annotation correctness across all handler domains
- **`tests/tools.test.ts`**: Updated export jsonl test for new multi-item content structure

### Why

MCP 2025-06-18 supports `annotations` on content items with `audience` and `priority` fields. This helps clients:
- Show formatted summaries to users while feeding raw JSON to the LLM
- Prioritize high-importance content (errors) over low-importance (empty results)
- Suppress noisy JSON dumps from user-facing displays

All 371 tests pass.

Fixes #93