### PR TITLE
feat: outputSchema + resource_link (MCP 2025-06-18)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -72,7 +72,7 @@ export function validateContentLength(content: string, label = 'content'): void 
 // Content annotation helpers (MCP 2025-06-18)
 // ---------------------------------------------------------------------------
 
-import type { ContentAnnotations, TextContentItem } from './handlers/types.js';
+import type { ContentAnnotations, TextContentItem, ResourceLinkContentItem } from './handlers/types.js';
 
 /**
  * Build a text content item intended for both user and assistant display.
@@ -110,3 +110,21 @@ export const UPDATE_FIELDS = new Set([
   'content', 'importance', 'memory_type', 'namespace',
   'metadata', 'expires_at', 'pinned', 'tags', 'immutable',
 ]);
+
+// ---------------------------------------------------------------------------
+// Resource link helpers (MCP 2025-06-18)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a resource_link content item pointing to a memory resource.
+ * Mutation tools should include these to let clients subscribe to or fetch
+ * the created/modified memory via the resource system.
+ */
+export function memoryResourceLink(id: string, name?: string): ResourceLinkContentItem {
+  return {
+    type: 'resource_link',
+    uri: `memoclaw://memories/${id}`,
+    name: name || `Memory ${id}`,
+    mimeType: 'application/json',
+  };
+}

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, extname, basename } from 'node:path';
-import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText } from '../format.js';
+import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
@@ -55,9 +55,14 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         messages, text, namespace, session_id, agent_id, auto_relate: auto_relate !== false,
       });
       const count = result.memories_created ?? result.count ?? '?';
+      const memories = result.memories || result.data || [];
+      const resourceLinks = memories
+        .filter((m: any) => m.id)
+        .map((m: any) => memoryResourceLink(m.id, 'Ingested memory'));
       return { content: [
         userAndAssistantText(`📥 Ingested: ${count} memories created`),
         assistantText(JSON.stringify(result, null, 2)),
+        ...resourceLinks,
       ] };
     }
 
@@ -186,9 +191,14 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const prefix = dry_run ? '🔍 Migration preview (dry run)' : '✅ Migration complete';
         const created = result.memories_created ?? result.count ?? '?';
         const skipped = result.duplicates_skipped ?? 0;
+        const migratedMemories = result.memories || result.data || [];
+        const resourceLinks = migratedMemories
+          .filter((m: any) => m.id)
+          .map((m: any) => memoryResourceLink(m.id, 'Migrated memory'));
         return { content: [
           userAndAssistantText(`${prefix}\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${created}\n🔄 Duplicates skipped: ${skipped}`),
           assistantText(JSON.stringify(result, null, 2)),
+          ...resourceLinks,
         ] };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
@@ -410,10 +420,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         lines.push('\nBy namespace:');
         for (const n of result.by_namespace) lines.push(`  • ${n.namespace || '(default)'}: ${n.count}`);
       }
-      return { content: [
-        userText(`📊 Memory Stats\n\n${lines.join('\n')}`, 0.5),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userText(`📊 Memory Stats\n\n${lines.join('\n')}`, 0.5),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: result,
+      };
     }
 
     default:

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -1,4 +1,4 @@
-import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS, userAndAssistantText, assistantText, userText } from '../format.js';
+import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StoreArgs, GetArgs, ListArgs, UpdateArgs, DeleteArgs,
@@ -28,20 +28,29 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (pinned !== undefined) body.pinned = pinned;
       if (immutable !== undefined) body.immutable = immutable;
       const result = await makeRequest('POST', '/v1/store', body);
-      return { content: [
-        userAndAssistantText(`✅ Memory stored\n${formatMemory(result.memory || result)}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      const memory = result.memory || result;
+      return {
+        content: [
+          userAndAssistantText(`✅ Memory stored\n${formatMemory(memory)}`),
+          assistantText(JSON.stringify(result, null, 2)),
+          ...(memory.id ? [memoryResourceLink(memory.id, 'Stored memory')] : []),
+        ],
+        structuredContent: { memory },
+      };
     }
 
     case 'memoclaw_get': {
       const { id } = args as GetArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('GET', `/v1/memories/${id}`);
-      return { content: [
-        userAndAssistantText(formatMemory(result.memory || result)),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      const memory = result.memory || result;
+      return {
+        content: [
+          userAndAssistantText(formatMemory(memory)),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memory },
+      };
     }
 
     case 'memoclaw_list': {
@@ -61,10 +70,13 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       const formatted = memories.length > 0
         ? '\n\n' + memories.map((m: any) => formatMemory(m)).join('\n\n')
         : '';
-      return { content: [
-        userAndAssistantText(`Showing ${memories.length} of ${total} memories${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`Showing ${memories.length} of ${total} memories${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memories, total },
+      };
     }
 
     case 'memoclaw_update': {
@@ -80,10 +92,15 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (typeof updateFields.content === 'string') validateContentLength(updateFields.content);
       validateImportance(updateFields.importance);
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, updateFields);
-      return { content: [
-        userAndAssistantText(`✅ Memory ${id} updated\n${formatMemory(result.memory || result)}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      const memory = result.memory || result;
+      return {
+        content: [
+          userAndAssistantText(`✅ Memory ${id} updated\n${formatMemory(memory)}`),
+          assistantText(JSON.stringify(result, null, 2)),
+          memoryResourceLink(id, 'Updated memory'),
+        ],
+        structuredContent: { memory },
+      };
     }
 
     case 'memoclaw_delete': {
@@ -169,7 +186,8 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
           text += `\n\nErrors:\n${errors.join('\n')}`;
         }
-        return { content: [userAndAssistantText(text)] };
+        const resourceLinks = stored.filter((m: any) => m.id).map((m: any) => memoryResourceLink(m.id, 'Stored memory'));
+        return { content: [userAndAssistantText(text), ...resourceLinks] };
       } catch (batchErr: any) {
         // Fall back to one-by-one if batch endpoint is unavailable (404)
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
@@ -200,7 +218,8 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       let text = `✅ Bulk store: ${succeeded.length} stored, ${failed.length} failed`;
       if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [userAndAssistantText(text)] };
+      const resourceLinks = stored.filter((m: any) => m?.id).map((m: any) => memoryResourceLink(m.id, 'Stored memory'));
+      return { content: [userAndAssistantText(text), ...resourceLinks] };
     }
 
     case 'memoclaw_import': {
@@ -240,7 +259,8 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
           text += `\n\nErrors:\n${errors.join('\n')}`;
         }
-        return { content: [userAndAssistantText(text)] };
+        const resourceLinks = stored.filter((m: any) => m.id).map((m: any) => memoryResourceLink(m.id, 'Imported memory'));
+        return { content: [userAndAssistantText(text), ...resourceLinks] };
       } catch (batchErr: any) {
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
           throw batchErr;
@@ -277,14 +297,20 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       const { id } = args as PinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
-      return { content: [userAndAssistantText(`📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}`)] };
+      return { content: [
+        userAndAssistantText(`📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}`),
+        memoryResourceLink(id, 'Pinned memory'),
+      ] };
     }
 
     case 'memoclaw_unpin': {
       const { id } = args as UnpinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
-      return { content: [userAndAssistantText(`📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}`)] };
+      return { content: [
+        userAndAssistantText(`📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}`),
+        memoryResourceLink(id, 'Unpinned memory'),
+      ] };
     }
 
     case 'memoclaw_batch_update': {
@@ -303,9 +329,13 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         const memories = result.memories || [];
         let text = `✅ Batch update: ${updated} memories updated`;
         if (memories.length > 0) text += `\n\n${memories.map((m: any) => formatMemory(m)).join('\n\n')}`;
+        const batchResourceLinks = memories
+          .filter((m: any) => m.id)
+          .map((m: any) => memoryResourceLink(m.id, 'Updated memory'));
         return { content: [
           userAndAssistantText(text),
           assistantText(JSON.stringify(result, null, 2)),
+          ...batchResourceLinks,
         ] };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
@@ -330,7 +360,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           let text = `✅ Batch update: ${succeeded.length} updated, ${failed.length} failed`;
           if (memories.length > 0) text += `\n\n${memories.map((m: any) => formatMemory(m)).join('\n\n')}`;
           if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-          return { content: [userAndAssistantText(text)] };
+          const fallbackResourceLinks = updates
+            .filter((_u: any, i: number) => results[i].status === 'fulfilled')
+            .map((u: any) => memoryResourceLink(u.id, 'Updated memory'));
+          return { content: [userAndAssistantText(text), ...fallbackResourceLinks] };
         }
         throw err;
       }
@@ -380,7 +413,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
       const filters = [namespace && `namespace=${namespace}`, memory_type && `type=${memory_type}`, agent_id && `agent=${agent_id}`, tags?.length && `tags=${tags.join(',')}`].filter(Boolean);
       const filterStr = filters.length > 0 ? ` (${filters.join(', ')})` : '';
-      return { content: [userText(`📊 Total memories${filterStr}: ${total}`, 0.5)] };
+      return {
+        content: [userText(`📊 Total memories${filterStr}: ${total}`, 0.5)],
+        structuredContent: { count: typeof total === 'number' ? total : undefined },
+      };
     }
 
     default:

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -25,10 +25,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
         return { content: [userText(`No memories found for query: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [
-        userAndAssistantText(`Found ${memories.length} memories:\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`Found ${memories.length} memories:\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memories },
+      };
     }
 
     case 'memoclaw_search': {
@@ -51,10 +54,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
         return { content: [userText(`No memories found containing: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [
-        userAndAssistantText(`Found ${memories.length} memories containing "${query}":\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`Found ${memories.length} memories containing "${query}":\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memories },
+      };
     }
 
     case 'memoclaw_context': {

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -17,7 +17,21 @@ export interface TextContentItem {
   annotations?: ContentAnnotations;
 }
 
-export type ToolResult = { content: TextContentItem[]; isError?: boolean };
+/**
+ * MCP resource_link content item (MCP 2025-06-18).
+ * Returned by mutation tools to link to created/modified resources.
+ */
+export interface ResourceLinkContentItem {
+  type: 'resource_link';
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export type ContentItem = TextContentItem | ResourceLinkContentItem;
+
+export type ToolResult = { content: ContentItem[]; isError?: boolean; structuredContent?: Record<string, unknown> };
 
 export type ToolHandler = (name: string, args: any) => Promise<ToolResult>;
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -14,6 +14,39 @@
 
 const MEMORY_TYPE_ENUM = ['correction', 'preference', 'decision', 'project', 'observation', 'general'] as const;
 
+// ── Output schemas (MCP 2025-06-18) ─────────────────────────────────────────
+// When outputSchema is present, tool results include structured JSON content
+// alongside human-readable text. Clients can parse the structured block directly.
+
+const MEMORY_OBJECT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    id: { type: 'string' as const },
+    content: { type: 'string' as const },
+    importance: { type: 'number' as const },
+    memory_type: { type: 'string' as const },
+    namespace: { type: 'string' as const },
+    tags: { type: 'array' as const, items: { type: 'string' as const } },
+    pinned: { type: 'boolean' as const },
+    immutable: { type: 'boolean' as const },
+    expires_at: { type: 'string' as const },
+    created_at: { type: 'string' as const },
+    updated_at: { type: 'string' as const },
+    session_id: { type: 'string' as const },
+    agent_id: { type: 'string' as const },
+  },
+  required: ['id', 'content'] as string[],
+};
+
+const RECALL_RESULT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    ...MEMORY_OBJECT_SCHEMA.properties,
+    similarity: { type: 'number' as const },
+  },
+  required: ['id', 'content'] as string[],
+};
+
 const COMMON_FILTERS = {
   tags: { type: 'array' as const, items: { type: 'string' as const }, description: 'Filter by tags (memories must have ALL specified tags).' },
   namespace: { type: 'string' as const, description: 'Filter by namespace.' },
@@ -54,6 +87,13 @@ export const TOOLS = [
       },
       required: ['content'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memory: MEMORY_OBJECT_SCHEMA,
+      },
+      required: ['memory'] as string[],
+    },
   },
   {
     name: 'memoclaw_recall',
@@ -81,6 +121,13 @@ export const TOOLS = [
       },
       required: ['query'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: RECALL_RESULT_SCHEMA },
+      },
+      required: ['memories'] as string[],
+    },
   },
   {
     name: 'memoclaw_search',
@@ -104,6 +151,13 @@ export const TOOLS = [
       },
       required: ['query'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['memories'] as string[],
+    },
   },
   {
     name: 'memoclaw_get',
@@ -122,6 +176,13 @@ export const TOOLS = [
         id: { type: 'string', description: 'The memory ID to retrieve.' },
       },
       required: ['id'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memory: MEMORY_OBJECT_SCHEMA,
+      },
+      required: ['memory'] as string[],
     },
   },
   {
@@ -144,6 +205,14 @@ export const TOOLS = [
         offset: { type: 'number', description: 'Pagination offset. Default: 0.' },
         ...COMMON_FILTERS,
       },
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        total: { type: 'number' as const },
+      },
+      required: ['memories', 'total'] as string[],
     },
   },
   {
@@ -209,6 +278,13 @@ export const TOOLS = [
         immutable: { type: 'boolean', description: 'Set to true to make this memory immutable. WARNING: This is a one-way operation — once set, the memory cannot be updated or deleted.' },
       },
       required: ['id'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memory: MEMORY_OBJECT_SCHEMA,
+      },
+      required: ['memory'] as string[],
     },
   },
   {
@@ -486,6 +562,13 @@ export const TOOLS = [
         memory_type: { type: 'string', enum: MEMORY_TYPE_ENUM, description: 'Count only memories of this type.' },
       },
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        count: { type: 'number' as const },
+      },
+      required: ['count'] as string[],
+    },
   },
   {
     name: 'memoclaw_delete_namespace',
@@ -751,5 +834,19 @@ export const TOOLS = [
       openWorldHint: false,
     },
     inputSchema: { type: 'object' as const, properties: {} },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        total_memories: { type: 'number' as const },
+        pinned_count: { type: 'number' as const },
+        never_accessed: { type: 'number' as const },
+        total_accesses: { type: 'number' as const },
+        avg_importance: { type: 'number' as const },
+        oldest_memory: { type: 'string' as const },
+        newest_memory: { type: 'string' as const },
+        by_type: { type: 'array' as const, items: { type: 'object' as const, properties: { memory_type: { type: 'string' as const }, count: { type: 'number' as const } } } },
+        by_namespace: { type: 'array' as const, items: { type: 'object' as const, properties: { namespace: { type: 'string' as const }, count: { type: 'number' as const } } } },
+      },
+    },
   },
 ];

--- a/tests/annotations.test.ts
+++ b/tests/annotations.test.ts
@@ -21,11 +21,11 @@ function createMockContext(mockResponse: any = {}): HandlerContext {
 
 describe('Content Annotations', () => {
   describe('Memory handlers', () => {
-    it('memoclaw_store returns annotated content with separated JSON', async () => {
+    it('memoclaw_store returns annotated content with separated JSON and resource_link', async () => {
       const ctx = createMockContext({ memory: { id: '1', content: 'test' } });
       const result = await handleMemory(ctx, 'memoclaw_store', { content: 'test' });
       expect(result).not.toBeNull();
-      expect(result!.content.length).toBe(2);
+      expect(result!.content.length).toBe(3);
 
       // Formatted text: user + assistant audience
       const formatted = result!.content[0];
@@ -38,6 +38,15 @@ describe('Content Annotations', () => {
       expect(raw.annotations?.audience).toEqual(['assistant']);
       expect(raw.annotations?.priority).toBe(0.3);
       expect(raw.text).toContain('{');
+
+      // Resource link to stored memory
+      const link = result!.content[2];
+      expect(link.type).toBe('resource_link');
+      expect((link as any).uri).toBe('memoclaw://memories/1');
+
+      // structuredContent
+      expect(result!.structuredContent).toBeDefined();
+      expect((result!.structuredContent as any).memory.id).toBe('1');
     });
 
     it('memoclaw_get returns annotated content', async () => {

--- a/tests/output-schema-and-resource-links.test.ts
+++ b/tests/output-schema-and-resource-links.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for MCP 2025-06-18 features:
+ * - outputSchema on tool definitions (#91)
+ * - resource_link content items in mutation results (#92)
+ * - structuredContent in tool results
+ */
+import { describe, it, expect } from 'vitest';
+import { TOOLS } from '../src/tools.js';
+import { handleMemory } from '../src/handlers/memory.js';
+import { handleRecall } from '../src/handlers/recall.js';
+import { handleAdmin } from '../src/handlers/admin.js';
+import type { HandlerContext } from '../src/handlers/types.js';
+
+function createMockContext(mockResponse: any = {}): HandlerContext {
+  return {
+    api: {} as any,
+    config: { apiUrl: 'https://api.memoclaw.com', privateKey: '0x1234', configSource: 'env', timeout: 30000, maxRetries: 3, allowedOrigins: 'any' } as any,
+    makeRequest: async () => mockResponse,
+    account: { address: '0xTestWallet' } as any,
+  };
+}
+
+// ── outputSchema on tool definitions (#91) ───────────────────────────────────
+
+describe('outputSchema on tool definitions (#91)', () => {
+  const toolMap = new Map(TOOLS.map(t => [t.name, t]));
+
+  it('memoclaw_store has outputSchema with memory object', () => {
+    const tool = toolMap.get('memoclaw_store')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.type).toBe('object');
+    expect(tool.outputSchema!.properties.memory).toBeDefined();
+    expect(tool.outputSchema!.required).toContain('memory');
+  });
+
+  it('memoclaw_get has outputSchema with memory object', () => {
+    const tool = toolMap.get('memoclaw_get')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.memory).toBeDefined();
+    expect(tool.outputSchema!.required).toContain('memory');
+  });
+
+  it('memoclaw_recall has outputSchema with memories array', () => {
+    const tool = toolMap.get('memoclaw_recall')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.memories).toBeDefined();
+    // Recall items include similarity score
+    const itemSchema = (tool.outputSchema!.properties.memories as any).items;
+    expect(itemSchema.properties.similarity).toBeDefined();
+    expect(itemSchema.properties.similarity.type).toBe('number');
+  });
+
+  it('memoclaw_search has outputSchema with memories array', () => {
+    const tool = toolMap.get('memoclaw_search')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.memories).toBeDefined();
+    expect(tool.outputSchema!.required).toContain('memories');
+  });
+
+  it('memoclaw_list has outputSchema with memories array and total', () => {
+    const tool = toolMap.get('memoclaw_list')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.memories).toBeDefined();
+    expect(tool.outputSchema!.properties.total).toBeDefined();
+    expect(tool.outputSchema!.required).toEqual(expect.arrayContaining(['memories', 'total']));
+  });
+
+  it('memoclaw_update has outputSchema with memory object', () => {
+    const tool = toolMap.get('memoclaw_update')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.memory).toBeDefined();
+  });
+
+  it('memoclaw_count has outputSchema with count number', () => {
+    const tool = toolMap.get('memoclaw_count')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.count).toBeDefined();
+    expect((tool.outputSchema!.properties.count as any).type).toBe('number');
+    expect(tool.outputSchema!.required).toContain('count');
+  });
+
+  it('memoclaw_stats has outputSchema with stats fields', () => {
+    const tool = toolMap.get('memoclaw_stats')!;
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema!.properties.total_memories).toBeDefined();
+    expect(tool.outputSchema!.properties.by_type).toBeDefined();
+    expect(tool.outputSchema!.properties.by_namespace).toBeDefined();
+  });
+
+  it('outputSchema.type is always "object" per MCP spec', () => {
+    for (const tool of TOOLS) {
+      if ((tool as any).outputSchema) {
+        expect((tool as any).outputSchema.type, `${tool.name} outputSchema.type`).toBe('object');
+      }
+    }
+  });
+
+  it('memory object schema has required id and content', () => {
+    const tool = toolMap.get('memoclaw_store')!;
+    const memSchema = tool.outputSchema!.properties.memory as any;
+    expect(memSchema.required).toContain('id');
+    expect(memSchema.required).toContain('content');
+  });
+
+  it('tools without structured output do not have outputSchema', () => {
+    // Destructive/admin tools that return unstructured text shouldn't have outputSchema
+    const noSchemaTools = ['memoclaw_delete', 'memoclaw_bulk_delete', 'memoclaw_delete_namespace',
+      'memoclaw_init', 'memoclaw_status', 'memoclaw_ingest', 'memoclaw_extract',
+      'memoclaw_consolidate', 'memoclaw_migrate'];
+    for (const name of noSchemaTools) {
+      const tool = toolMap.get(name)!;
+      expect((tool as any).outputSchema, `${name} should NOT have outputSchema`).toBeUndefined();
+    }
+  });
+});
+
+// ── resource_link in mutation results (#92) ──────────────────────────────────
+
+describe('resource_link in mutation tool results (#92)', () => {
+  it('memoclaw_store returns resource_link to stored memory', async () => {
+    const ctx = createMockContext({ memory: { id: 'abc-123', content: 'test' } });
+    const result = await handleMemory(ctx, 'memoclaw_store', { content: 'test' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(1);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/abc-123');
+    expect((links[0] as any).mimeType).toBe('application/json');
+  });
+
+  it('memoclaw_update returns resource_link to updated memory', async () => {
+    const ctx = createMockContext({ memory: { id: 'xyz', content: 'updated' } });
+    const result = await handleMemory(ctx, 'memoclaw_update', { id: 'xyz', content: 'updated' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(1);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/xyz');
+    expect((links[0] as any).name).toBe('Updated memory');
+  });
+
+  it('memoclaw_pin returns resource_link', async () => {
+    const ctx = createMockContext({ memory: { id: 'pin-1', content: 'pinned', pinned: true } });
+    const result = await handleMemory(ctx, 'memoclaw_pin', { id: 'pin-1' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(1);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/pin-1');
+  });
+
+  it('memoclaw_unpin returns resource_link', async () => {
+    const ctx = createMockContext({ memory: { id: 'unpin-1', content: 'unpinned', pinned: false } });
+    const result = await handleMemory(ctx, 'memoclaw_unpin', { id: 'unpin-1' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(1);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/unpin-1');
+  });
+
+  it('memoclaw_bulk_store returns resource_links for stored memories', async () => {
+    const ctx = createMockContext({
+      memories: [{ id: 'b1', content: 'a' }, { id: 'b2', content: 'b' }],
+      failed: [],
+    });
+    const result = await handleMemory(ctx, 'memoclaw_bulk_store', {
+      memories: [{ content: 'a' }, { content: 'b' }],
+    });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(2);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/b1');
+    expect((links[1] as any).uri).toBe('memoclaw://memories/b2');
+  });
+
+  it('memoclaw_import returns resource_links for imported memories', async () => {
+    const ctx = createMockContext({
+      memories: [{ id: 'i1', content: 'imported' }],
+      failed: [],
+    });
+    const result = await handleMemory(ctx, 'memoclaw_import', {
+      memories: [{ content: 'imported' }],
+    });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(1);
+    expect((links[0] as any).uri).toBe('memoclaw://memories/i1');
+    expect((links[0] as any).name).toBe('Imported memory');
+  });
+
+  it('memoclaw_store skips resource_link when no id returned', async () => {
+    const ctx = createMockContext({ memory: { content: 'no id' } });
+    const result = await handleMemory(ctx, 'memoclaw_store', { content: 'no id' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(0);
+  });
+
+  it('read-only tools do NOT return resource_links', async () => {
+    const ctx = createMockContext({ memories: [{ id: '1', content: 'test', similarity: 0.9 }] });
+    const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'test' });
+    const links = result!.content.filter(c => c.type === 'resource_link');
+    expect(links).toHaveLength(0);
+  });
+});
+
+// ── structuredContent in results ─────────────────────────────────────────────
+
+describe('structuredContent in tool results', () => {
+  it('memoclaw_store includes structuredContent with memory', async () => {
+    const ctx = createMockContext({ memory: { id: '1', content: 'test' } });
+    const result = await handleMemory(ctx, 'memoclaw_store', { content: 'test' });
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).memory.id).toBe('1');
+  });
+
+  it('memoclaw_get includes structuredContent with memory', async () => {
+    const ctx = createMockContext({ memory: { id: '1', content: 'hello' } });
+    const result = await handleMemory(ctx, 'memoclaw_get', { id: '1' });
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).memory.content).toBe('hello');
+  });
+
+  it('memoclaw_list includes structuredContent with memories and total', async () => {
+    const ctx = createMockContext({ memories: [{ id: '1', content: 'a' }], total: 1 });
+    const result = await handleMemory(ctx, 'memoclaw_list', {});
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).memories).toHaveLength(1);
+    expect((result!.structuredContent as any).total).toBe(1);
+  });
+
+  it('memoclaw_recall includes structuredContent with memories', async () => {
+    const ctx = createMockContext({ memories: [{ id: '1', content: 'test', similarity: 0.95 }] });
+    const result = await handleRecall(ctx, 'memoclaw_recall', { query: 'test' });
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).memories[0].similarity).toBe(0.95);
+  });
+
+  it('memoclaw_update includes structuredContent with memory', async () => {
+    const ctx = createMockContext({ memory: { id: '1', content: 'updated' } });
+    const result = await handleMemory(ctx, 'memoclaw_update', { id: '1', content: 'updated' });
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).memory.content).toBe('updated');
+  });
+
+  it('memoclaw_count includes structuredContent with count', async () => {
+    const ctx = createMockContext({ count: 42 });
+    const result = await handleMemory(ctx, 'memoclaw_count', {});
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).count).toBe(42);
+  });
+
+  it('memoclaw_stats includes structuredContent', async () => {
+    const ctx = createMockContext({ total_memories: 100, pinned_count: 5 });
+    const result = await handleAdmin(ctx, 'memoclaw_stats', {});
+    expect(result!.structuredContent).toBeDefined();
+    expect((result!.structuredContent as any).total_memories).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Implements two MCP 2025-06-18 spec features in a single PR.

### 1. outputSchema on tool definitions (Fixes #91)

Adds `outputSchema` JSON Schema to tools that return structured data, enabling MCP clients to parse results programmatically:

| Tool | Output Schema |
|------|--------------|
| `memoclaw_store`, `memoclaw_get`, `memoclaw_update` | `{ memory: MemoryObject }` |
| `memoclaw_recall` | `{ memories: MemoryObject[] }` (with `similarity` score) |
| `memoclaw_search` | `{ memories: MemoryObject[] }` |
| `memoclaw_list` | `{ memories: MemoryObject[], total: number }` |
| `memoclaw_count` | `{ count: number }` |
| `memoclaw_stats` | Stats object with breakdowns |

Tools with unstructured output (delete, init, status, ingest, etc.) intentionally omit `outputSchema`.

### 2. resource_link content items in mutation results (Fixes #92)

Mutation tools now return `resource_link` content items pointing to `memoclaw://memories/{id}` URIs:

- `memoclaw_store` → link to stored memory
- `memoclaw_update` → link to updated memory
- `memoclaw_pin` / `memoclaw_unpin` → link to modified memory
- `memoclaw_bulk_store` → links to all stored memories
- `memoclaw_import` → links to all imported memories

This enables MCP clients to subscribe to memory resources for live updates and build richer UIs.

### Additional: structuredContent

Mutation and query handlers now also return `structuredContent` on the result object for direct programmatic access.

### Tests

- 26 new tests covering both features
- All 397 tests pass
- Updated existing annotation tests for new content structure

### Files Changed

- `src/tools.ts` — outputSchema definitions
- `src/handlers/types.ts` — ResourceLinkContentItem type
- `src/format.ts` — memoryResourceLink() helper
- `src/handlers/memory.ts` — resource_links + structuredContent
- `src/handlers/recall.ts` — structuredContent
- `src/handlers/admin.ts` — structuredContent for stats
- `tests/output-schema-and-resource-links.test.ts` — new test file
- `tests/annotations.test.ts` — updated for resource_link