### PR TITLE
fix: add metadata to UpdateArgs, before date filter, parallel graph traversal

### DIFF
--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -54,7 +54,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_list': {
-      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after } = args as ListArgs;
+      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after, before } = args as ListArgs;
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (offset !== undefined) params.set('offset', String(offset));
@@ -64,6 +64,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (session_id) params.set('session_id', session_id);
       if (agent_id) params.set('agent_id', agent_id);
       if (after) params.set('after', after);
+      if (before) params.set('before', before);
       const result = await makeRequest('GET', `/v1/memories?${params}`);
       const memories = result.memories || result.data || [];
       const total = result.total ?? memories.length;

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -7,7 +7,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
 
   switch (name) {
     case 'memoclaw_recall': {
-      const { query, limit, min_similarity, tags, namespace, memory_type, session_id, agent_id, include_relations, after } = args as RecallArgs;
+      const { query, limit, min_similarity, tags, namespace, memory_type, session_id, agent_id, include_relations, after, before } = args as RecallArgs;
       if (!query || (typeof query === 'string' && query.trim() === '')) {
         throw new Error('query is required and cannot be empty');
       }
@@ -15,6 +15,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (tags) filters.tags = tags;
       if (memory_type) filters.memory_type = memory_type;
       if (after) filters.after = after;
+      if (before) filters.before = before;
       const result = await makeRequest('POST', '/v1/recall', {
         query, limit, min_similarity,
         filters: Object.keys(filters).length > 0 ? filters : undefined,
@@ -35,7 +36,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_search': {
-      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after } = args as SearchArgs;
+      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after, before } = args as SearchArgs;
       if (!query || (typeof query === 'string' && query.trim() === '')) {
         throw new Error('query is required and cannot be empty');
       }
@@ -48,6 +49,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (session_id) params.set('session_id', session_id);
       if (agent_id) params.set('agent_id', agent_id);
       if (after) params.set('after', after);
+      if (before) params.set('before', before);
       const result = await makeRequest('GET', `/v1/memories/search?${params}`);
       const memories = result.memories || result.data || [];
       if (memories.length === 0) {

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,4 +1,4 @@
-import { formatMemory, userAndAssistantText, assistantText, userText } from '../format.js';
+import { formatMemory, withConcurrency, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { CreateRelationArgs, ListRelationsArgs, DeleteRelationArgs, GraphArgs } from '../types.js';
 
@@ -58,26 +58,42 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
       for (let d = 0; d <= depth && frontier.length > 0; d++) {
         const nextFrontier: string[] = [];
-        for (const mid of frontier) {
-          if (visited.has(mid)) continue;
-          visited.add(mid);
-          try {
-            const mem = await makeRequest('GET', `/v1/memories/${mid}`);
-            nodes.push(mem.memory || mem);
-          } catch {
-            nodes.push({ id: mid, content: '(could not fetch)' });
-          }
-          if (d < depth) {
-            try {
-              const relResult = await makeRequest('GET', `/v1/memories/${mid}/relations`);
-              const relations = relResult.relations || [];
-              for (const r of relations) {
-                if (relation_type && r.relation_type !== relation_type) continue;
-                edges.push(r);
-                const neighbor = r.target_id === mid ? r.source_id : r.target_id;
+        const unvisited = frontier.filter(mid => !visited.has(mid));
+        if (unvisited.length === 0) break;
+        for (const mid of unvisited) visited.add(mid);
+
+        // Fetch all memories at this depth level in parallel
+        const memResults = await withConcurrency(
+          unvisited.map(mid => () =>
+            makeRequest('GET', `/v1/memories/${mid}`)
+              .then(mem => ({ id: mid, data: mem.memory || mem }))
+              .catch(() => ({ id: mid, data: { id: mid, content: '(could not fetch)' } }))
+          ),
+          10
+        );
+        for (const r of memResults) {
+          if (r.status === 'fulfilled') nodes.push(r.value.data);
+        }
+
+        // Fetch all relations at this depth level in parallel
+        if (d < depth) {
+          const relResults = await withConcurrency(
+            unvisited.map(mid => () =>
+              makeRequest('GET', `/v1/memories/${mid}/relations`)
+                .then(relResult => ({ id: mid, relations: relResult.relations || [] }))
+                .catch(() => ({ id: mid, relations: [] as any[] }))
+            ),
+            10
+          );
+          for (const r of relResults) {
+            if (r.status === 'fulfilled') {
+              for (const rel of r.value.relations) {
+                if (relation_type && rel.relation_type !== relation_type) continue;
+                edges.push(rel);
+                const neighbor = rel.target_id === r.value.id ? rel.source_id : rel.target_id;
                 if (neighbor && !visited.has(neighbor)) nextFrontier.push(neighbor);
               }
-            } catch { /* no relations */ }
+            }
           }
         }
         frontier = nextFrontier;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -54,6 +54,7 @@ const COMMON_FILTERS = {
   session_id: { type: 'string' as const, description: 'Filter by session ID.' },
   agent_id: { type: 'string' as const, description: 'Filter by agent ID.' },
   after: { type: 'string' as const, description: 'Only return memories created after this ISO 8601 date, e.g. "2025-01-01T00:00:00Z".' },
+  before: { type: 'string' as const, description: 'Only return memories created before this ISO 8601 date, e.g. "2025-12-31T23:59:59Z".' },
 };
 
 export const TOOLS = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface RecallArgs {
   agent_id?: string;
   include_relations?: boolean;
   after?: string;
+  before?: string;
 }
 
 export interface SearchArgs {
@@ -42,6 +43,7 @@ export interface SearchArgs {
   session_id?: string;
   agent_id?: string;
   after?: string;
+  before?: string;
 }
 
 export interface GetArgs {
@@ -57,6 +59,7 @@ export interface ListArgs {
   session_id?: string;
   agent_id?: string;
   after?: string;
+  before?: string;
 }
 
 export interface DeleteArgs {
@@ -74,6 +77,7 @@ export interface UpdateArgs {
   tags?: string[];
   namespace?: string;
   memory_type?: string;
+  metadata?: Record<string, unknown>;
   pinned?: boolean;
   immutable?: boolean;
   expires_at?: string;
@@ -89,6 +93,7 @@ export interface BatchUpdateEntry {
   tags?: string[];
   namespace?: string;
   memory_type?: string;
+  metadata?: Record<string, unknown>;
   pinned?: boolean;
   immutable?: boolean;
   expires_at?: string;

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -89,6 +89,15 @@ describe('handleMemory', () => {
       const result = await handleMemory(ctx, 'memoclaw_list', {});
       expect(result!.content[0].text).toContain('0 of 0');
     });
+
+    it('passes before filter as query param', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories': { memories: [], total: 0 },
+      });
+      await handleMemory(ctx, 'memoclaw_list', { before: '2025-06-01T00:00:00Z' });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('before=2025-06-01T00%3A00%3A00Z');
+    });
   });
 
   // ── update ───────────────────────────────────────────────────────────────
@@ -111,6 +120,15 @@ describe('handleMemory', () => {
       const { ctx } = makeCtx();
       await expect(handleMemory(ctx, 'memoclaw_update', { id: '1', bad_field: 'x' }))
         .rejects.toThrow('No valid update fields');
+    });
+
+    it('passes metadata field to API', async () => {
+      const { ctx, api } = makeCtx({
+        'PATCH /v1/memories/': { memory: { id: '1', content: 'test' } },
+      });
+      await handleMemory(ctx, 'memoclaw_update', { id: '1', metadata: { key: 'val' } });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.metadata).toEqual({ key: 'val' });
     });
   });
 

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -47,6 +47,29 @@ describe('handleRecall', () => {
       expect(body.namespace).toBe('ns');
       expect(body.limit).toBe(5);
     });
+
+    it('passes before filter to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', {
+        query: 'test', before: '2025-06-01T00:00:00Z',
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters.before).toBe('2025-06-01T00:00:00Z');
+    });
+
+    it('passes both after and before filters to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', {
+        query: 'test', after: '2025-01-01T00:00:00Z', before: '2025-06-01T00:00:00Z',
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters.after).toBe('2025-01-01T00:00:00Z');
+      expect(body.filters.before).toBe('2025-06-01T00:00:00Z');
+    });
   });
 
   describe('memoclaw_search', () => {
@@ -62,6 +85,15 @@ describe('handleRecall', () => {
       const { ctx } = makeCtx();
       await expect(handleRecall(ctx, 'memoclaw_search', { query: '  ' }))
         .rejects.toThrow('query is required');
+    });
+
+    it('passes before filter as query param', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories/search': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_search', { query: 'test', before: '2025-12-31T00:00:00Z' });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('before=2025-12-31T00%3A00%3A00Z');
     });
   });
 


### PR DESCRIPTION
## Changes

### Bug fix: Missing metadata field in UpdateArgs (#100)
The `memoclaw_update` tool's input schema and handler both support a `metadata` field, but the TypeScript `UpdateArgs` and `BatchUpdateEntry` interfaces were missing it. This meant TypeScript couldn't catch type errors related to metadata updates.

### Enhancement: `before` date filter (#100)
Added a `before` date filter to complement the existing `after` filter, enabling date range queries across:
- `memoclaw_recall` (semantic search)
- `memoclaw_search` (keyword search)
- `memoclaw_list` (browse)

### Performance: Parallel graph traversal (#101)
Refactored `memoclaw_graph` to use `withConcurrency` for parallel memory and relation fetches at each depth level, instead of sequential per-node fetching. This significantly improves performance for wider graphs.

### Tests
- 5 new tests added (402 total, all passing)
- Tests for `before` filter on recall, search, and list
- Test for metadata update passthrough

Fixes #100
Fixes #101