### PR TITLE
feat: add outputSchema to all tools for MCP 2025-06-18 compliance

### DIFF
--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -16,13 +16,19 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const data = await makeRequest('GET', '/v1/free-tier/status');
       const remaining = data.free_tier_remaining ?? 'unknown';
       const total = data.free_tier_total ?? 100;
+      const wallet = data.wallet || account.address;
       const pct = typeof remaining === 'number' ? Math.round((remaining / total) * 100) : '?';
-      return { content: [userText(`Wallet: ${data.wallet || account.address}\nFree tier: ${remaining}/${total} calls remaining (${pct}%)`, 0.5)] };
+      return {
+        content: [userText(`Wallet: ${wallet}\nFree tier: ${remaining}/${total} calls remaining (${pct}%)`, 0.5)],
+        structuredContent: { wallet, free_tier_remaining: remaining, free_tier_total: total },
+      };
     }
 
     case 'memoclaw_init': {
       const checks: string[] = [];
       let healthy = true;
+      let freeTierRemaining: number | undefined;
+      let freeTierTotal: number | undefined;
       checks.push(`✅ Private key loaded (source: ${config.configSource})`);
       checks.push(`📍 API URL: ${config.apiUrl}`);
       checks.push(`👛 Wallet: ${account.address}`);
@@ -30,6 +36,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const data = await makeRequest('GET', '/v1/free-tier/status');
         const remaining = data.free_tier_remaining ?? 'unknown';
         const total = data.free_tier_total ?? 100;
+        freeTierRemaining = typeof remaining === 'number' ? remaining : undefined;
+        freeTierTotal = typeof total === 'number' ? total : undefined;
         checks.push(`✅ API reachable`);
         checks.push(`📊 Free tier: ${remaining}/${total} calls remaining`);
         if (typeof remaining === 'number' && remaining <= 0) {
@@ -45,7 +53,18 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         checks.push(`   4. Restart the MCP server`);
       }
       const status = healthy ? '🟢 MemoClaw is ready!' : '🔴 MemoClaw needs configuration';
-      return { content: [userText(`${status}\n\n${checks.join('\n')}`, healthy ? 0.5 : 1.0)] };
+      const structured: Record<string, unknown> = {
+        healthy,
+        wallet: account.address,
+        api_url: config.apiUrl,
+        config_source: config.configSource,
+      };
+      if (freeTierRemaining !== undefined) structured.free_tier_remaining = freeTierRemaining;
+      if (freeTierTotal !== undefined) structured.free_tier_total = freeTierTotal;
+      return {
+        content: [userText(`${status}\n\n${checks.join('\n')}`, healthy ? 0.5 : 1.0)],
+        structuredContent: structured,
+      };
     }
 
     case 'memoclaw_ingest': {
@@ -54,16 +73,19 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const result = await makeRequest('POST', '/v1/ingest', {
         messages, text, namespace, session_id, agent_id, auto_relate: auto_relate !== false,
       });
-      const count = result.memories_created ?? result.count ?? '?';
+      const memoriesCreated = result.memories_created ?? result.count ?? 0;
       const memories = result.memories || result.data || [];
       const resourceLinks = memories
         .filter((m: any) => m.id)
         .map((m: any) => memoryResourceLink(m.id, 'Ingested memory'));
-      return { content: [
-        userAndAssistantText(`📥 Ingested: ${count} memories created`),
-        assistantText(JSON.stringify(result, null, 2)),
-        ...resourceLinks,
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`📥 Ingested: ${memoriesCreated} memories created`),
+          assistantText(JSON.stringify(result, null, 2)),
+          ...resourceLinks,
+        ],
+        structuredContent: { memories_created: memoriesCreated, memories },
+      };
     }
 
     case 'memoclaw_extract': {
@@ -72,7 +94,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         throw new Error('messages is required and must be a non-empty array');
       }
       const result = await makeRequest('POST', '/v1/memories/extract', { messages, namespace, session_id, agent_id });
-      return { content: [assistantText(JSON.stringify(result, null, 2))] };
+      return {
+        content: [assistantText(JSON.stringify(result, null, 2))],
+        structuredContent: result,
+      };
     }
 
     case 'memoclaw_consolidate': {
@@ -85,10 +110,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       if (dry_run !== undefined) body.dry_run = dry_run;
       const result = await makeRequest('POST', '/v1/memories/consolidate', body);
       const prefix = dry_run ? '🔍 Consolidation preview (dry run)' : '✅ Consolidation complete';
-      return { content: [
-        userAndAssistantText(prefix),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(prefix),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: result,
+      };
     }
 
     case 'memoclaw_export': {
@@ -105,10 +133,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const output = fmt === 'jsonl'
           ? list.map((m: any) => JSON.stringify(m)).join('\n')
           : JSON.stringify(list, null, 2);
-        return { content: [
-          userAndAssistantText(`📦 Exported ${list.length} memories`),
-          assistantText(output),
-        ] };
+        return {
+          content: [
+            userAndAssistantText(`📦 Exported ${list.length} memories`),
+            assistantText(output),
+          ],
+          structuredContent: { memories: list, count: list.length },
+        };
       } catch (exportErr: any) {
         // Only fall back to pagination if /v1/export is not found (404)
         if (!exportErr.message?.includes('404') && !exportErr.message?.includes('Not Found')) {
@@ -133,10 +164,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const output = fmt === 'jsonl'
           ? allMemories.map((m: any) => JSON.stringify(m)).join('\n')
           : JSON.stringify(allMemories, null, 2);
-        return { content: [
-          userAndAssistantText(`📦 Exported ${allMemories.length} memories`),
-          assistantText(output),
-        ] };
+        return {
+          content: [
+            userAndAssistantText(`📦 Exported ${allMemories.length} memories`),
+            assistantText(output),
+          ],
+          structuredContent: { memories: allMemories, count: allMemories.length },
+        };
       }
     }
 
@@ -195,15 +229,21 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const resourceLinks = migratedMemories
           .filter((m: any) => m.id)
           .map((m: any) => memoryResourceLink(m.id, 'Migrated memory'));
-        return { content: [
-          userAndAssistantText(`${prefix}\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${created}\n🔄 Duplicates skipped: ${skipped}`),
-          assistantText(JSON.stringify(result, null, 2)),
-          ...resourceLinks,
-        ] };
+        return {
+          content: [
+            userAndAssistantText(`${prefix}\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${created}\n🔄 Duplicates skipped: ${skipped}`),
+            assistantText(JSON.stringify(result, null, 2)),
+            ...resourceLinks,
+          ],
+          structuredContent: { files_processed: fileList.length, memories_created: typeof created === 'number' ? created : 0, duplicates_skipped: skipped, memories: migratedMemories },
+        };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
           if (dry_run) {
-            return { content: [userAndAssistantText(`🔍 Migration preview (dry run — /v1/migrate not available, would use ingest fallback)\n\n📁 ${fileList.length} files would be ingested:\n${fileList.map(f => `  • ${f.filename} (${f.content.length} chars)`).join('\n')}`)] };
+            return {
+              content: [userAndAssistantText(`🔍 Migration preview (dry run — /v1/migrate not available, would use ingest fallback)\n\n📁 ${fileList.length} files would be ingested:\n${fileList.map(f => `  • ${f.filename} (${f.content.length} chars)`).join('\n')}`)],
+              structuredContent: { files_processed: fileList.length, memories_created: 0, duplicates_skipped: 0, memories: [] },
+            };
           }
           let totalCreated = 0;
           const errors: string[] = [];
@@ -221,7 +261,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
           }
           let text = `✅ Migration complete (via ingest fallback)\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${totalCreated}`;
           if (errors.length > 0) text += `\n\n❌ Errors:\n${errors.join('\n')}`;
-          return { content: [userAndAssistantText(text)] };
+          return {
+            content: [userAndAssistantText(text)],
+            structuredContent: { files_processed: fileList.length, memories_created: totalCreated, duplicates_skipped: 0, memories: [] },
+          };
         }
         throw err;
       }
@@ -268,7 +311,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
       let text = `🗑️ Namespace "${namespace}": ${deletedIds.length} memories deleted`;
       if (errors.length > 0) text += `, ${errors.length} failed\n\nErrors:\n${errors.slice(0, 10).join('\n')}`;
-      return { content: [userAndAssistantText(text)] };
+      return {
+        content: [userAndAssistantText(text)],
+        structuredContent: { deleted: deletedIds.length, failed: errors.length, namespace, errors: errors.slice(0, 10) },
+      };
     }
 
     case 'memoclaw_tags': {
@@ -281,11 +327,12 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const result = await makeRequest('GET', `/v1/tags${qs ? '?' + qs : ''}`);
         if (result.tags) {
           const tags = result.tags;
-          if (tags.length === 0) return { content: [userText('No tags found across memories.', 0.3)] };
-          const lines = tags.map((t: any) =>
-            typeof t === 'string' ? `  • ${t}` : `  • ${t.tag || t.name}: ${t.count} memories`
+          if (tags.length === 0) return { content: [userText('No tags found across memories.', 0.3)], structuredContent: { tags: [] } };
+          const normalized = tags.map((t: any) =>
+            typeof t === 'string' ? { tag: t, count: 0 } : { tag: t.tag || t.name, count: t.count ?? 0 }
           );
-          return { content: [userText(`🏷️ ${tags.length} tags:\n\n${lines.join('\n')}`, 0.5)] };
+          const lines = normalized.map((t: any) => `  • ${t.tag}: ${t.count} memories`);
+          return { content: [userText(`🏷️ ${tags.length} tags:\n\n${lines.join('\n')}`, 0.5)], structuredContent: { tags: normalized } };
         }
       } catch { /* fall through to client-side */ }
 
@@ -308,10 +355,11 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (memories.length < pageSize) break;
         offset += pageSize;
       }
-      if (tagCounts.size === 0) return { content: [userText('No tags found across memories.', 0.3)] };
+      if (tagCounts.size === 0) return { content: [userText('No tags found across memories.', 0.3)], structuredContent: { tags: [] } };
       const sorted = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
+      const normalizedTags = sorted.map(([tag, count]) => ({ tag, count }));
       const lines = sorted.map(([tag, count]) => `  • ${tag}: ${count} memories`);
-      return { content: [userText(`🏷️ ${sorted.length} tags:\n\n${lines.join('\n')}`, 0.5)] };
+      return { content: [userText(`🏷️ ${sorted.length} tags:\n\n${lines.join('\n')}`, 0.5)], structuredContent: { tags: normalizedTags } };
     }
 
     case 'memoclaw_history': {
@@ -320,7 +368,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const result = await makeRequest('GET', `/v1/memories/${id}/history`);
       const history = result.history || result.versions || result.data || [];
       if (history.length === 0) {
-        return { content: [userText(`No edit history found for memory ${id}.`, 0.3)] };
+        return { content: [userText(`No edit history found for memory ${id}.`, 0.3)], structuredContent: { history: [] } };
       }
       const formatted = history.map((entry: any, i: number) => {
         const parts = [`Version ${i + 1}`];
@@ -336,10 +384,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (entry.changed_fields) parts.push(`  changed: ${Array.isArray(entry.changed_fields) ? entry.changed_fields.join(', ') : entry.changed_fields}`);
         return parts.join('\n');
       }).join('\n\n');
-      return { content: [
-        userAndAssistantText(`📜 History for memory ${id} (${history.length} versions):\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`📜 History for memory ${id} (${history.length} versions):\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { history },
+      };
     }
 
     case 'memoclaw_namespaces': {
@@ -351,11 +402,12 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const result = await makeRequest('GET', `/v1/namespaces${qs ? '?' + qs : ''}`);
         if (result.namespaces) {
           const namespaces = result.namespaces;
-          if (namespaces.length === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)] };
-          const lines = namespaces.map((n: any) =>
-            typeof n === 'string' ? `  • ${n}` : `  • ${n.namespace || n.name || '(default)'}: ${n.count} memories`
+          if (namespaces.length === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)], structuredContent: { namespaces: [] } };
+          const normalized = namespaces.map((n: any) =>
+            typeof n === 'string' ? { namespace: n, count: 0 } : { namespace: n.namespace || n.name || '(default)', count: n.count ?? 0 }
           );
-          return { content: [userText(`📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}`, 0.5)] };
+          const lines = normalized.map((n: any) => `  • ${n.namespace}: ${n.count} memories`);
+          return { content: [userText(`📁 ${namespaces.length} namespaces:\n\n${lines.join('\n')}`, 0.5)], structuredContent: { namespaces: normalized } };
         }
       } catch { /* fall through */ }
 
@@ -377,10 +429,11 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (memories.length < pageSize) break;
         offset += pageSize;
       }
-      if (nsCounts.size === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)] };
+      if (nsCounts.size === 0) return { content: [userText('No memories found — no namespaces to list.', 0.3)], structuredContent: { namespaces: [] } };
       const sorted = [...nsCounts.entries()].sort((a, b) => b[1] - a[1]);
+      const normalizedNs = sorted.map(([ns, count]) => ({ namespace: ns, count }));
       const lines = sorted.map(([ns, count]) => `  • ${ns}: ${count} memories`);
-      return { content: [userText(`📁 ${sorted.length} namespaces:\n\n${lines.join('\n')}`, 0.5)] };
+      return { content: [userText(`📁 ${sorted.length} namespaces:\n\n${lines.join('\n')}`, 0.5)], structuredContent: { namespaces: normalizedNs } };
     }
 
     case 'memoclaw_core_memories': {
@@ -393,13 +446,16 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const result = await makeRequest('GET', `/v1/core-memories${qs ? '?' + qs : ''}`);
       const memories = result.memories || result.core_memories || result.data || [];
       if (memories.length === 0) {
-        return { content: [userText('No core memories found. Store important memories with high importance scores or pin them.', 0.3)] };
+        return { content: [userText('No core memories found. Store important memories with high importance scores or pin them.', 0.3)], structuredContent: { memories: [] } };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [
-        userAndAssistantText(`⭐ ${memories.length} core memories:\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`⭐ ${memories.length} core memories:\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memories },
+      };
     }
 
     case 'memoclaw_stats': {

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -108,10 +108,13 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       const { id } = args as DeleteArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('DELETE', `/v1/memories/${id}`);
-      return { content: [
-        userAndAssistantText(`🗑️ Memory ${id} deleted`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`🗑️ Memory ${id} deleted`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { deleted: true, id },
+      };
     }
 
     case 'memoclaw_bulk_delete': {
@@ -147,7 +150,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
       let text = `🗑️ Bulk delete: ${succeeded} succeeded, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [userAndAssistantText(text)] };
+      return {
+        content: [userAndAssistantText(text)],
+        structuredContent: { succeeded, failed, errors },
+      };
     }
 
     case 'memoclaw_bulk_store': {
@@ -183,12 +189,16 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         const failedItems = result.failed || [];
         let text = `✅ Bulk store: ${stored.length} stored, ${failedItems.length} failed`;
         if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
+        const bulkErrors: string[] = [];
         if (failedItems.length > 0) {
-          const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
-          text += `\n\nErrors:\n${errors.join('\n')}`;
+          for (const f of failedItems) bulkErrors.push(`index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
+          text += `\n\nErrors:\n${bulkErrors.join('\n')}`;
         }
         const resourceLinks = stored.filter((m: any) => m.id).map((m: any) => memoryResourceLink(m.id, 'Stored memory'));
-        return { content: [userAndAssistantText(text), ...resourceLinks] };
+        return {
+          content: [userAndAssistantText(text), ...resourceLinks],
+          structuredContent: { succeeded: stored.length, failed: failedItems.length, memories: stored, errors: bulkErrors },
+        };
       } catch (batchErr: any) {
         // Fall back to one-by-one if batch endpoint is unavailable (404)
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
@@ -220,7 +230,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
       const resourceLinks = stored.filter((m: any) => m?.id).map((m: any) => memoryResourceLink(m.id, 'Stored memory'));
-      return { content: [userAndAssistantText(text), ...resourceLinks] };
+      return {
+        content: [userAndAssistantText(text), ...resourceLinks],
+        structuredContent: { succeeded: succeeded.length, failed: failed.length, memories: stored, errors },
+      };
     }
 
     case 'memoclaw_import': {
@@ -256,12 +269,16 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         const stored = result.memories || result.data || [];
         const failedItems = result.failed || [];
         let text = `📥 Import: ${stored.length} stored, ${failedItems.length} failed`;
+        const importErrors: string[] = [];
         if (failedItems.length > 0) {
-          const errors = failedItems.map((f: any) => `index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
-          text += `\n\nErrors:\n${errors.join('\n')}`;
+          for (const f of failedItems) importErrors.push(`index ${f.index ?? '?'}: ${f.error || 'unknown error'}`);
+          text += `\n\nErrors:\n${importErrors.join('\n')}`;
         }
         const resourceLinks = stored.filter((m: any) => m.id).map((m: any) => memoryResourceLink(m.id, 'Imported memory'));
-        return { content: [userAndAssistantText(text), ...resourceLinks] };
+        return {
+          content: [userAndAssistantText(text), ...resourceLinks],
+          structuredContent: { succeeded: stored.length, failed: failedItems.length, errors: importErrors },
+        };
       } catch (batchErr: any) {
         if (!batchErr.message?.includes('404') && !batchErr.message?.includes('Not Found')) {
           throw batchErr;
@@ -291,27 +308,38 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         .filter(Boolean);
       let text = `📥 Import: ${succeeded} stored, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
-      return { content: [userAndAssistantText(text)] };
+      return {
+        content: [userAndAssistantText(text)],
+        structuredContent: { succeeded, failed, errors },
+      };
     }
 
     case 'memoclaw_pin': {
       const { id } = args as PinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
-      return { content: [
-        userAndAssistantText(`📌 Memory ${id} pinned\n${formatMemory(result.memory || result)}`),
-        memoryResourceLink(id, 'Pinned memory'),
-      ] };
+      const memory = result.memory || result;
+      return {
+        content: [
+          userAndAssistantText(`📌 Memory ${id} pinned\n${formatMemory(memory)}`),
+          memoryResourceLink(id, 'Pinned memory'),
+        ],
+        structuredContent: { memory },
+      };
     }
 
     case 'memoclaw_unpin': {
       const { id } = args as UnpinArgs;
       if (!id) throw new Error('id is required');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
-      return { content: [
-        userAndAssistantText(`📌 Memory ${id} unpinned\n${formatMemory(result.memory || result)}`),
-        memoryResourceLink(id, 'Unpinned memory'),
-      ] };
+      const memory = result.memory || result;
+      return {
+        content: [
+          userAndAssistantText(`📌 Memory ${id} unpinned\n${formatMemory(memory)}`),
+          memoryResourceLink(id, 'Unpinned memory'),
+        ],
+        structuredContent: { memory },
+      };
     }
 
     case 'memoclaw_batch_update': {
@@ -333,11 +361,14 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         const batchResourceLinks = memories
           .filter((m: any) => m.id)
           .map((m: any) => memoryResourceLink(m.id, 'Updated memory'));
-        return { content: [
-          userAndAssistantText(text),
-          assistantText(JSON.stringify(result, null, 2)),
-          ...batchResourceLinks,
-        ] };
+        return {
+          content: [
+            userAndAssistantText(text),
+            assistantText(JSON.stringify(result, null, 2)),
+            ...batchResourceLinks,
+          ],
+          structuredContent: { updated: typeof updated === 'number' ? updated : memories.length, failed: 0, memories, errors: [] },
+        };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
           const results = await withConcurrency(
@@ -364,7 +395,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           const fallbackResourceLinks = updates
             .filter((_u: any, i: number) => results[i].status === 'fulfilled')
             .map((u: any) => memoryResourceLink(u.id, 'Updated memory'));
-          return { content: [userAndAssistantText(text), ...fallbackResourceLinks] };
+          return {
+            content: [userAndAssistantText(text), ...fallbackResourceLinks],
+            structuredContent: { updated: succeeded.length, failed: failed.length, memories, errors },
+          };
         }
         throw err;
       }

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -81,10 +81,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
         return { content: [userText(`No relevant context found for: "${query}"`, 0.3)] };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [
-        userAndAssistantText(`🧠 Context for "${query}" (${memories.length} memories):\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`🧠 Context for "${query}" (${memories.length} memories):\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { memories },
+      };
     }
 
     case 'memoclaw_suggested': {
@@ -102,10 +105,13 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
         return { content: [userText(`No suggestions found${category ? ` for category "${category}"` : ''}.`, 0.3)] };
       }
       const formatted = suggestions.map((m: any) => formatMemory(m)).join('\n\n');
-      return { content: [
-        userAndAssistantText(`💡 ${suggestions.length} suggestions${category ? ` (${category})` : ''}:\n\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`💡 ${suggestions.length} suggestions${category ? ` (${category})` : ''}:\n\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { suggestions },
+      };
     }
 
     default:

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -14,10 +14,14 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const body: any = { target_id, relation_type };
       if (metadata) body.metadata = metadata;
       const result = await makeRequest('POST', `/v1/memories/${memory_id}/relations`, body);
-      return { content: [
-        userAndAssistantText(`🔗 Relation created: ${memory_id} —[${relation_type}]→ ${target_id}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      const relation = result.relation || result;
+      return {
+        content: [
+          userAndAssistantText(`🔗 Relation created: ${memory_id} —[${relation_type}]→ ${target_id}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { relation },
+      };
     }
 
     case 'memoclaw_list_relations': {
@@ -31,20 +35,26 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const formatted = relations.map((r: any) =>
         `🔗 ${r.id || '?'}: ${r.source_id || memory_id} —[${r.relation_type}]→ ${r.target_id}`
       ).join('\n');
-      return { content: [
-        userAndAssistantText(`Relations for ${memory_id}:\n${formatted}`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`Relations for ${memory_id}:\n${formatted}`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { relations },
+      };
     }
 
     case 'memoclaw_delete_relation': {
       const { memory_id, relation_id } = args as DeleteRelationArgs;
       if (!memory_id || !relation_id) throw new Error('memory_id and relation_id are required');
       const result = await makeRequest('DELETE', `/v1/memories/${memory_id}/relations/${relation_id}`);
-      return { content: [
-        userAndAssistantText(`🗑️ Relation ${relation_id} deleted`),
-        assistantText(JSON.stringify(result, null, 2)),
-      ] };
+      return {
+        content: [
+          userAndAssistantText(`🗑️ Relation ${relation_id} deleted`),
+          assistantText(JSON.stringify(result, null, 2)),
+        ],
+        structuredContent: { deleted: true, relation_id },
+      };
     }
 
     case 'memoclaw_graph': {
@@ -101,7 +111,10 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
       const nodesFmt = nodes.map((n: any) => formatMemory(n)).join('\n\n');
       const edgesFmt = edges.map((r: any) => `  ${r.source_id} —[${r.relation_type}]→ ${r.target_id}`).join('\n');
-      return { content: [userAndAssistantText(`🕸️ Graph from ${memory_id} (depth ${depth}):\n\n${nodes.length} nodes:\n${nodesFmt}\n\n${edges.length} edges:\n${edgesFmt || '  (none)'}`)] };
+      return {
+        content: [userAndAssistantText(`🕸️ Graph from ${memory_id} (depth ${depth}):\n\n${nodes.length} nodes:\n${nodesFmt}\n\n${edges.length} edges:\n${edgesFmt || '  (none)'}`)],
+        structuredContent: { nodes, edges },
+      };
     }
 
     default:

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -47,6 +47,36 @@ const RECALL_RESULT_SCHEMA = {
   required: ['id', 'content'] as string[],
 };
 
+const RELATION_OBJECT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    id: { type: 'string' as const },
+    source_id: { type: 'string' as const },
+    target_id: { type: 'string' as const },
+    relation_type: { type: 'string' as const },
+    metadata: { type: 'object' as const },
+  },
+  required: ['source_id', 'target_id', 'relation_type'] as string[],
+};
+
+const TAG_OBJECT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    tag: { type: 'string' as const },
+    count: { type: 'number' as const },
+  },
+  required: ['tag', 'count'] as string[],
+};
+
+const NAMESPACE_OBJECT_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    namespace: { type: 'string' as const },
+    count: { type: 'number' as const },
+  },
+  required: ['namespace', 'count'] as string[],
+};
+
 const COMMON_FILTERS = {
   tags: { type: 'array' as const, items: { type: 'string' as const }, description: 'Filter by tags (memories must have ALL specified tags).' },
   namespace: { type: 'string' as const, description: 'Filter by namespace.' },
@@ -233,6 +263,14 @@ export const TOOLS = [
       },
       required: ['id'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        deleted: { type: 'boolean' as const },
+        id: { type: 'string' as const },
+      },
+      required: ['deleted', 'id'] as string[],
+    },
   },
   {
     name: 'memoclaw_bulk_delete',
@@ -250,6 +288,15 @@ export const TOOLS = [
         ids: { type: 'array', items: { type: 'string' }, description: 'Array of memory IDs to delete. Max 100.' },
       },
       required: ['ids'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        succeeded: { type: 'number' as const },
+        failed: { type: 'number' as const },
+        errors: { type: 'array' as const, items: { type: 'string' as const } },
+      },
+      required: ['succeeded', 'failed'] as string[],
     },
   },
   {
@@ -299,6 +346,15 @@ export const TOOLS = [
       openWorldHint: false,
     },
     inputSchema: { type: 'object' as const, properties: {} },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        wallet: { type: 'string' as const },
+        free_tier_remaining: { type: 'number' as const },
+        free_tier_total: { type: 'number' as const },
+      },
+      required: ['wallet', 'free_tier_remaining', 'free_tier_total'] as string[],
+    },
   },
   {
     name: 'memoclaw_ingest',
@@ -323,6 +379,14 @@ export const TOOLS = [
         auto_relate: { type: 'boolean', description: 'Auto-create relations between extracted facts. Default: true.' },
       },
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories_created: { type: 'number' as const },
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['memories_created'] as string[],
+    },
   },
   {
     name: 'memoclaw_extract',
@@ -346,6 +410,13 @@ export const TOOLS = [
       },
       required: ['messages'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        facts: { type: 'array' as const, items: { type: 'object' as const, properties: { content: { type: 'string' as const }, importance: { type: 'number' as const }, memory_type: { type: 'string' as const } } } },
+      },
+    },
   },
   {
     name: 'memoclaw_consolidate',
@@ -366,6 +437,14 @@ export const TOOLS = [
         min_similarity: { type: 'number', description: 'Minimum similarity for duplicates (0.0-1.0).' },
         mode: { type: 'string', description: 'Consolidation strategy/mode.' },
         dry_run: { type: 'boolean', description: 'If true, returns what WOULD be merged without actually merging.' },
+      },
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        merged: { type: 'number' as const },
+        deleted: { type: 'number' as const },
+        clusters: { type: 'array' as const, items: { type: 'object' as const, properties: { kept: { type: 'string' as const }, merged_ids: { type: 'array' as const, items: { type: 'string' as const } } } } },
       },
     },
   },
@@ -390,6 +469,13 @@ export const TOOLS = [
         category: { type: 'string', enum: ['stale', 'fresh', 'hot', 'decaying'], description: 'Filter by category.' },
       },
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        suggestions: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['suggestions'] as string[],
+    },
   },
   {
     name: 'memoclaw_create_relation',
@@ -412,6 +498,13 @@ export const TOOLS = [
       },
       required: ['memory_id', 'target_id', 'relation_type'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        relation: RELATION_OBJECT_SCHEMA,
+      },
+      required: ['relation'] as string[],
+    },
   },
   {
     name: 'memoclaw_list_relations',
@@ -429,6 +522,13 @@ export const TOOLS = [
         memory_id: { type: 'string', description: 'Memory ID to list relations for.' },
       },
       required: ['memory_id'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        relations: { type: 'array' as const, items: RELATION_OBJECT_SCHEMA },
+      },
+      required: ['relations'] as string[],
     },
   },
   {
@@ -449,6 +549,14 @@ export const TOOLS = [
       },
       required: ['memory_id', 'relation_id'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        deleted: { type: 'boolean' as const },
+        relation_id: { type: 'string' as const },
+      },
+      required: ['deleted', 'relation_id'] as string[],
+    },
   },
   {
     name: 'memoclaw_export',
@@ -467,6 +575,14 @@ export const TOOLS = [
         agent_id: { type: 'string', description: 'Only export memories from this agent.' },
         format: { type: 'string', enum: ['json', 'jsonl'], description: 'Export format. Default: "json".' },
       },
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        count: { type: 'number' as const },
+      },
+      required: ['memories', 'count'] as string[],
     },
   },
   {
@@ -505,6 +621,15 @@ export const TOOLS = [
       },
       required: ['memories'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        succeeded: { type: 'number' as const },
+        failed: { type: 'number' as const },
+        errors: { type: 'array' as const, items: { type: 'string' as const } },
+      },
+      required: ['succeeded', 'failed'] as string[],
+    },
   },
   {
     name: 'memoclaw_bulk_store',
@@ -542,6 +667,16 @@ export const TOOLS = [
         agent_id: { type: 'string', description: 'Agent ID applied to all memories.' },
       },
       required: ['memories'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        succeeded: { type: 'number' as const },
+        failed: { type: 'number' as const },
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        errors: { type: 'array' as const, items: { type: 'string' as const } },
+      },
+      required: ['succeeded', 'failed'] as string[],
     },
   },
   {
@@ -591,6 +726,16 @@ export const TOOLS = [
       },
       required: ['namespace'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        deleted: { type: 'number' as const },
+        failed: { type: 'number' as const },
+        namespace: { type: 'string' as const },
+        errors: { type: 'array' as const, items: { type: 'string' as const } },
+      },
+      required: ['deleted', 'namespace'] as string[],
+    },
   },
   {
     name: 'memoclaw_init',
@@ -605,6 +750,18 @@ export const TOOLS = [
       openWorldHint: false,
     },
     inputSchema: { type: 'object' as const, properties: {} },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        healthy: { type: 'boolean' as const },
+        wallet: { type: 'string' as const },
+        api_url: { type: 'string' as const },
+        config_source: { type: 'string' as const },
+        free_tier_remaining: { type: 'number' as const },
+        free_tier_total: { type: 'number' as const },
+      },
+      required: ['healthy', 'wallet'] as string[],
+    },
   },
   {
     name: 'memoclaw_migrate',
@@ -641,6 +798,16 @@ export const TOOLS = [
         dry_run: { type: 'boolean', description: 'Preview without storing.' },
       },
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        files_processed: { type: 'number' as const },
+        memories_created: { type: 'number' as const },
+        duplicates_skipped: { type: 'number' as const },
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['files_processed', 'memories_created'] as string[],
+    },
   },
   {
     name: 'memoclaw_graph',
@@ -662,6 +829,14 @@ export const TOOLS = [
       },
       required: ['memory_id'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        nodes: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        edges: { type: 'array' as const, items: RELATION_OBJECT_SCHEMA },
+      },
+      required: ['nodes', 'edges'] as string[],
+    },
   },
   {
     name: 'memoclaw_pin',
@@ -678,6 +853,13 @@ export const TOOLS = [
       properties: { id: { type: 'string', description: 'The memory ID to pin.' } },
       required: ['id'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memory: MEMORY_OBJECT_SCHEMA,
+      },
+      required: ['memory'] as string[],
+    },
   },
   {
     name: 'memoclaw_unpin',
@@ -693,6 +875,13 @@ export const TOOLS = [
       type: 'object' as const,
       properties: { id: { type: 'string', description: 'The memory ID to unpin.' } },
       required: ['id'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memory: MEMORY_OBJECT_SCHEMA,
+      },
+      required: ['memory'] as string[],
     },
   },
   {
@@ -712,6 +901,13 @@ export const TOOLS = [
         agent_id: { type: 'string', description: 'Only list tags for this agent.' },
       },
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        tags: { type: 'array' as const, items: TAG_OBJECT_SCHEMA },
+      },
+      required: ['tags'] as string[],
+    },
   },
   {
     name: 'memoclaw_history',
@@ -728,6 +924,28 @@ export const TOOLS = [
       properties: { id: { type: 'string', description: 'The memory ID to view history for.' } },
       required: ['id'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        history: {
+          type: 'array' as const,
+          items: {
+            type: 'object' as const,
+            properties: {
+              content: { type: 'string' as const },
+              importance: { type: 'number' as const },
+              memory_type: { type: 'string' as const },
+              namespace: { type: 'string' as const },
+              tags: { type: 'array' as const, items: { type: 'string' as const } },
+              pinned: { type: 'boolean' as const },
+              changed_at: { type: 'string' as const },
+              changed_fields: { type: 'array' as const, items: { type: 'string' as const } },
+            },
+          },
+        },
+      },
+      required: ['history'] as string[],
+    },
   },
   {
     name: 'memoclaw_namespaces',
@@ -742,6 +960,13 @@ export const TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: { agent_id: { type: 'string', description: 'Only list namespaces for this agent.' } },
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        namespaces: { type: 'array' as const, items: NAMESPACE_OBJECT_SCHEMA },
+      },
+      required: ['namespaces'] as string[],
     },
   },
   {
@@ -766,6 +991,13 @@ export const TOOLS = [
         agent_id: { type: 'string', description: 'Filter by agent.' },
       },
       required: ['query'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['memories'] as string[],
     },
   },
   {
@@ -804,6 +1036,16 @@ export const TOOLS = [
       },
       required: ['updates'],
     },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        updated: { type: 'number' as const },
+        failed: { type: 'number' as const },
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+        errors: { type: 'array' as const, items: { type: 'string' as const } },
+      },
+      required: ['updated'] as string[],
+    },
   },
   {
     name: 'memoclaw_core_memories',
@@ -822,6 +1064,13 @@ export const TOOLS = [
         namespace: { type: 'string', description: 'Filter by namespace.' },
         agent_id: { type: 'string', description: 'Filter by agent.' },
       },
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        memories: { type: 'array' as const, items: MEMORY_OBJECT_SCHEMA },
+      },
+      required: ['memories'] as string[],
     },
   },
   {

--- a/tests/output-schema-and-resource-links.test.ts
+++ b/tests/output-schema-and-resource-links.test.ts
@@ -102,14 +102,10 @@ describe('outputSchema on tool definitions (#91)', () => {
     expect(memSchema.required).toContain('content');
   });
 
-  it('tools without structured output do not have outputSchema', () => {
-    // Destructive/admin tools that return unstructured text shouldn't have outputSchema
-    const noSchemaTools = ['memoclaw_delete', 'memoclaw_bulk_delete', 'memoclaw_delete_namespace',
-      'memoclaw_init', 'memoclaw_status', 'memoclaw_ingest', 'memoclaw_extract',
-      'memoclaw_consolidate', 'memoclaw_migrate'];
-    for (const name of noSchemaTools) {
-      const tool = toolMap.get(name)!;
-      expect((tool as any).outputSchema, `${name} should NOT have outputSchema`).toBeUndefined();
+  it('all tools have outputSchema for MCP 2025-06-18 compliance', () => {
+    for (const tool of TOOLS) {
+      expect((tool as any).outputSchema, `${tool.name} should have outputSchema`).toBeDefined();
+      expect((tool as any).outputSchema.type, `${tool.name} outputSchema.type`).toBe('object');
     }
   });
 });


### PR DESCRIPTION
## Summary

Extends PR #98 to cover **ALL** remaining tools with `outputSchema` definitions, achieving full MCP 2025-06-18 compliance.

### What changed

PR #98 added `outputSchema` to 9 tools that return structured data (store, recall, search, get, list, count, stats, update). This PR adds it to the remaining **24 tools**:

| Category | Tools |
|----------|-------|
| **Delete/Cleanup** | delete, bulk_delete, delete_namespace |
| **Admin** | status, init |
| **AI Processing** | ingest, extract, consolidate, migrate |
| **Relations** | create_relation, list_relations, delete_relation, graph |
| **Memory Ops** | pin, unpin, batch_update, bulk_store, import, export |
| **Query** | suggested, context, core_memories |
| **Metadata** | tags, history, namespaces |

### Implementation

- **`src/tools.ts`**: Added `outputSchema` to all 24 remaining tools + 3 reusable helper schemas (`RELATION_OBJECT_SCHEMA`, `TAG_OBJECT_SCHEMA`, `NAMESPACE_OBJECT_SCHEMA`)
- **`src/handlers/memory.ts`**: Added `structuredContent` to delete, bulk_delete, bulk_store, import, pin, unpin, batch_update handlers
- **`src/handlers/recall.ts`**: Added `structuredContent` to context, suggested handlers
- **`src/handlers/admin.ts`**: Added `structuredContent` to status, init (init now also fetches free tier data when healthy)
- **`src/handlers/relations.ts`**: Added `structuredContent` to create_relation, list_relations, delete_relation, graph handlers
- **Tests**: Updated assertion to verify ALL 33 tools have `outputSchema`

### Testing

All **402 tests pass** ✅

Closes #99