### PR TITLE
feat: add memoclaw_check_duplicates tool + update @types/node to v25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-03-07
+
+### Added
+- `memoclaw_check_duplicates` tool — pre-store semantic dedup check that finds similar existing memories before storing new ones (Fixes #111)
+
+### Changed
+- Updated `@types/node` from v22 to v25 (Fixes #112)
+
 ## [1.14.0] - 2026-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Configure your MCP client to connect to `http://localhost:3100/mcp`.
 | `memoclaw_core_memories` | Get your most important/frequently accessed memories |
 | `memoclaw_stats` | Memory usage statistics |
 | `memoclaw_history` | View edit history for a memory |
+| `memoclaw_check_duplicates` | Check if similar content exists before storing |
 | `memoclaw_status` | Check free tier remaining calls |
 | `memoclaw_init` | Verify configuration and API connectivity |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "memoclaw-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.3.5",
         "typescript": "^5.7.0",
         "vitest": "^4.0.18"
       },
@@ -1072,13 +1072,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2823,9 +2823,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "viem": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.3.5",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -1,6 +1,6 @@
 import { formatMemory, userAndAssistantText, assistantText, userText } from '../format.js';
 import type { HandlerContext, ToolResult } from './types.js';
-import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs } from '../types.js';
+import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs, CheckDuplicatesArgs } from '../types.js';
 
 export async function handleRecall(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
   const { makeRequest } = ctx;
@@ -111,6 +111,47 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
           assistantText(JSON.stringify(result, null, 2)),
         ],
         structuredContent: { suggestions },
+      };
+    }
+
+    case 'memoclaw_check_duplicates': {
+      const { content, min_similarity, namespace, limit } = args as CheckDuplicatesArgs;
+      if (!content || (typeof content === 'string' && content.trim() === '')) {
+        throw new Error('content is required and cannot be empty');
+      }
+      const threshold = min_similarity ?? 0.7;
+      const maxResults = limit ?? 5;
+      const body: any = { query: content, limit: maxResults, min_similarity: threshold };
+      if (namespace) body.namespace = namespace;
+      const result = await makeRequest('POST', '/v1/recall', body);
+      const duplicates = result.memories || [];
+      const hasDuplicates = duplicates.length > 0;
+
+      let suggestion: string;
+      if (!hasDuplicates) {
+        suggestion = 'No similar memories found. Safe to store.';
+      } else {
+        const topSim = duplicates[0]?.similarity;
+        if (typeof topSim === 'number' && topSim >= 0.9) {
+          suggestion = `Very similar memory exists (${(topSim * 100).toFixed(0)}% match). Consider updating memory ${duplicates[0].id} instead of creating a new one.`;
+        } else if (typeof topSim === 'number' && topSim >= 0.7) {
+          suggestion = `Similar memory found (${(topSim * 100).toFixed(0)}% match). Review before storing to avoid duplication.`;
+        } else {
+          suggestion = `Weakly similar memories found. Probably safe to store as new.`;
+        }
+      }
+
+      let text: string;
+      if (!hasDuplicates) {
+        text = `✅ No duplicates found (threshold: ${threshold}). Safe to store.`;
+      } else {
+        const formatted = duplicates.map((m: any) => formatMemory(m)).join('\n\n');
+        text = `⚠️ Found ${duplicates.length} potential duplicate(s) (threshold: ${threshold}):\n\n${formatted}\n\n💡 ${suggestion}`;
+      }
+
+      return {
+        content: [userAndAssistantText(text)],
+        structuredContent: { has_duplicates: hasDuplicates, duplicates, suggestion },
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import type { LogLevel } from './logging.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let VERSION = '1.14.0';
+let VERSION = '1.15.0';
 try {
   const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
   VERSION = pkg.version;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1099,4 +1099,38 @@ export const TOOLS = [
       },
     },
   },
+  {
+    name: 'memoclaw_check_duplicates',
+    description:
+      '🔍 PRE-STORE DEDUP: Check if similar content already exists before storing a new memory. ' +
+      'Returns potential duplicates above the similarity threshold. ' +
+      'Use this to avoid storing redundant memories and save API credits. ' +
+      'Internally uses semantic recall, so the cost is one recall call ($0.005).',
+    title: 'Check for duplicates',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        content: { type: 'string', description: 'The content you plan to store. This will be compared semantically against existing memories.' },
+        min_similarity: { type: 'number', description: 'Minimum similarity threshold (0.0-1.0). Default: 0.7. Higher values = stricter matching.' },
+        namespace: { type: 'string', description: 'Only check within this namespace.' },
+        limit: { type: 'number', description: 'Maximum number of potential duplicates to return. Default: 5.' },
+      },
+      required: ['content'],
+    },
+    outputSchema: {
+      type: 'object' as const,
+      properties: {
+        has_duplicates: { type: 'boolean' as const },
+        duplicates: { type: 'array' as const, items: RECALL_RESULT_SCHEMA },
+        suggestion: { type: 'string' as const },
+      },
+      required: ['has_duplicates', 'duplicates'] as string[],
+    },
+  },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,13 @@ export interface MigrateFile {
   content: string;
 }
 
+export interface CheckDuplicatesArgs {
+  content: string;
+  min_similarity?: number;
+  namespace?: string;
+  limit?: number;
+}
+
 export interface MigrateArgs {
   path?: string;
   files?: MigrateFile[];
@@ -313,7 +320,8 @@ export type ToolArgs =
   | { name: 'memoclaw_namespaces'; args: NamespacesArgs }
   | { name: 'memoclaw_core_memories'; args: CoreMemoriesArgs }
   | { name: 'memoclaw_stats'; args: StatsArgs }
-  | { name: 'memoclaw_migrate'; args: MigrateArgs };
+  | { name: 'memoclaw_migrate'; args: MigrateArgs }
+  | { name: 'memoclaw_check_duplicates'; args: CheckDuplicatesArgs };
 
 /** Map from tool name to its args type */
 export type ToolArgsMap = {

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -141,6 +141,71 @@ describe('handleRecall', () => {
     });
   });
 
+  describe('memoclaw_check_duplicates', () => {
+    it('reports no duplicates when recall returns empty', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_check_duplicates', { content: 'unique content' });
+      expect(result!.content[0].text).toContain('No duplicates found');
+      expect(result!.structuredContent!.has_duplicates).toBe(false);
+      expect(result!.structuredContent!.duplicates).toEqual([]);
+    });
+
+    it('reports duplicates when similar memories exist', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [{ id: '1', content: 'similar content', similarity: 0.92 }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_check_duplicates', { content: 'similar content' });
+      expect(result!.content[0].text).toContain('potential duplicate');
+      expect(result!.structuredContent!.has_duplicates).toBe(true);
+      expect((result!.structuredContent!.duplicates as any[]).length).toBe(1);
+    });
+
+    it('suggests updating for very high similarity (>= 0.9)', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [{ id: 'abc', content: 'near-exact', similarity: 0.95 }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_check_duplicates', { content: 'near-exact' });
+      expect(result!.structuredContent!.suggestion).toContain('updating memory abc');
+    });
+
+    it('suggests review for moderate similarity (0.7-0.9)', async () => {
+      const { ctx } = makeCtx({
+        'POST /v1/recall': { memories: [{ id: '1', content: 'related', similarity: 0.78 }] },
+      });
+      const result = await handleRecall(ctx, 'memoclaw_check_duplicates', { content: 'related' });
+      expect(result!.structuredContent!.suggestion).toContain('Review before storing');
+    });
+
+    it('uses default min_similarity of 0.7', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_check_duplicates', { content: 'test' });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.min_similarity).toBe(0.7);
+    });
+
+    it('respects custom min_similarity and namespace', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_check_duplicates', {
+        content: 'test', min_similarity: 0.5, namespace: 'work',
+      });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.min_similarity).toBe(0.5);
+      expect(body.namespace).toBe('work');
+    });
+
+    it('rejects empty content', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRecall(ctx, 'memoclaw_check_duplicates', { content: '' }))
+        .rejects.toThrow('content is required');
+    });
+  });
+
   it('returns null for unknown tools', async () => {
     const { ctx } = makeCtx();
     expect(await handleRecall(ctx, 'memoclaw_store', {})).toBeNull();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -112,9 +112,9 @@ describe('Tool Definitions', () => {
     ]));
   });
 
-  it('has 33 tools total', async () => {
+  it('has 34 tools total', async () => {
     const result = await listToolsHandler();
-    expect(result.tools).toHaveLength(33);
+    expect(result.tools).toHaveLength(34);
   });
 
   it('every tool has a title and annotations with all required hints', async () => {


### PR DESCRIPTION
## Summary

Adds a new `memoclaw_check_duplicates` tool for pre-store deduplication and updates `@types/node` to v25.

### New tool: `memoclaw_check_duplicates`

A read-only tool that checks if similar content already exists before storing a new memory. Returns potential duplicates with similarity scores and actionable suggestions.

**Why:** Agents frequently store memories without knowing if similar content exists, leading to duplicates and wasted API credits ($0.005 per store). This tool lets agents make informed decisions before storing.

**Behavior:**
- Uses semantic recall internally with configurable `min_similarity` (default: 0.7)
- Returns `has_duplicates`, `duplicates` array, and a `suggestion` string
- For >= 90% match: suggests updating existing memory
- For 70-90% match: suggests review before storing
- Below threshold: confirms safe to store

**Annotations:** `readOnlyHint: true`, `idempotentHint: true`

### Other changes
- Updated `@types/node` from `^22.0.0` to `^25.0.0` (devDependency only)
- Version bump to 1.15.0
- CHANGELOG and README updated

### Tests
- 7 new unit tests covering: no duplicates, high similarity, moderate similarity, custom threshold, namespace filtering, empty content rejection
- All 409 tests pass

Fixes #111, Fixes #112