### PR TITLE
feat: add MCP progress notifications for long-running operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-03-08
+
+### Added
+- MCP progress notifications for long-running operations (Fixes #110)
+  - Handlers report progress via `notifications/progress` when client provides `_meta.progressToken`
+  - Supported tools: `bulk_store`, `bulk_delete`, `batch_update`, `delete_namespace`, `export` (fallback), `migrate` (fallback), and `import` (fallback)
+- Tests for progress notification callbacks and empty-result structuredContent
+
+### Fixed
+- Missing `structuredContent` on empty results for `memoclaw_recall`, `memoclaw_search`, `memoclaw_context`, `memoclaw_suggested`, and `memoclaw_list_relations` — clients parsing structured output now always get a predictable shape
+- Added `minimum`/`maximum` constraints to `depth` parameter in `memoclaw_graph` input schema (handler already clamped to 1-3)
+
 ## [1.15.0] - 2026-03-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types.js';
 
 export async function handleAdmin(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest, account, config } = ctx;
+  const { makeRequest, account, config, progress } = ctx;
 
   switch (name) {
     case 'memoclaw_status': {
@@ -149,7 +149,9 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const allMemories: any[] = [];
         let offset = 0;
         const pageSize = 100;
+        let exportPage = 0;
         while (true) {
+          exportPage++;
           const fallbackParams = new URLSearchParams();
           fallbackParams.set('limit', String(pageSize));
           fallbackParams.set('offset', String(offset));
@@ -158,6 +160,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
           const result = await makeRequest('GET', `/v1/memories?${fallbackParams}`);
           const memories = result.memories || result.data || [];
           allMemories.push(...memories);
+          await progress(allMemories.length, result.total ?? allMemories.length);
           if (memories.length < pageSize) break;
           offset += pageSize;
         }
@@ -247,7 +250,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
           }
           let totalCreated = 0;
           const errors: string[] = [];
-          for (const file of fileList) {
+          for (let fi = 0; fi < fileList.length; fi++) {
+            const file = fileList[fi];
             try {
               const r = await makeRequest('POST', '/v1/ingest', {
                 text: file.content,
@@ -258,6 +262,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
             } catch (e: any) {
               errors.push(`${file.filename}: ${e.message}`);
             }
+            await progress(fi + 1, fileList.length);
           }
           let text = `✅ Migration complete (via ingest fallback)\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${totalCreated}`;
           if (errors.length > 0) text += `\n\n❌ Errors:\n${errors.join('\n')}`;
@@ -305,6 +310,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
             errors.push(`${toDelete[i].id}: ${(deleteResults[i] as PromiseRejectedResult).reason?.message || 'unknown'}`);
           }
         }
+        await progress(deletedIds.length, deletedIds.length + (memories.length >= pageSize ? pageSize : 0));
         if (memories.length < pageSize) break;
         if (pageSuccesses === 0) break;
       }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,7 +1,7 @@
 import type { ApiClient } from '../api.js';
 import type { Config } from '../config.js';
 import { createContext } from './types.js';
-import type { ToolResult } from './types.js';
+import type { ToolResult, ProgressCallback } from './types.js';
 import { handleMemory } from './memory.js';
 import { handleRecall } from './recall.js';
 import { handleRelations } from './relations.js';
@@ -10,9 +10,9 @@ import { handleAdmin } from './admin.js';
 export type { ToolResult };
 
 export function createHandler(api: ApiClient, config: Config) {
-  const ctx = createContext(api, config);
+  return async function handleToolCall(name: string, args: any, progress?: ProgressCallback): Promise<ToolResult> {
+    const ctx = createContext(api, config, progress);
 
-  return async function handleToolCall(name: string, args: any): Promise<ToolResult> {
     // Try each domain handler in turn; first non-null result wins
     const result =
       await handleMemory(ctx, name, args) ??

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -7,7 +7,7 @@ import type {
 } from '../types.js';
 
 export async function handleMemory(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest } = ctx;
+  const { makeRequest, progress } = ctx;
 
   switch (name) {
     case 'memoclaw_store': {
@@ -137,8 +137,14 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         }
       } catch {
         // Fallback: delete one-by-one
+        let deleteProgress = 0;
         const results = await withConcurrency(
-          ids.map((id: string) => () => makeRequest('DELETE', `/v1/memories/${id}`)),
+          ids.map((id: string) => async () => {
+            const result = await makeRequest('DELETE', `/v1/memories/${id}`);
+            deleteProgress++;
+            await progress(deleteProgress, ids.length);
+            return result;
+          }),
           10
         );
         succeeded = results.filter(r => r.status === 'fulfilled').length;
@@ -207,15 +213,19 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       }
 
       // Fallback: store one-by-one with concurrency
+      let storeProgress = 0;
       const results = await withConcurrency(
-        memories.map((m: any) => () => {
+        memories.map((m: any) => async () => {
           const body: any = {};
           for (const key of STORE_FIELDS) {
             if (m[key] !== undefined) body[key] = m[key];
           }
           if (session_id) body.session_id = session_id;
           if (agent_id) body.agent_id = agent_id;
-          return makeRequest('POST', '/v1/store', body);
+          const result = await makeRequest('POST', '/v1/store', body);
+          storeProgress++;
+          await progress(storeProgress, memories.length);
+          return result;
         }),
         10
       );
@@ -286,8 +296,9 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       }
 
       // Fallback: store one-by-one with concurrency
+      let importProgress = 0;
       const results = await withConcurrency(
-        memories.map((m: any) => () => {
+        memories.map((m: any) => async () => {
           const body: any = { content: m.content };
           if (m.importance !== undefined) body.importance = m.importance;
           if (m.tags) body.tags = m.tags;
@@ -297,7 +308,10 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           if (m.immutable !== undefined) body.immutable = m.immutable;
           if (session_id) body.session_id = session_id;
           if (agent_id) body.agent_id = agent_id;
-          return makeRequest('POST', '/v1/store', body);
+          const result = await makeRequest('POST', '/v1/store', body);
+          importProgress++;
+          await progress(importProgress, memories.length);
+          return result;
         }),
         10
       );
@@ -371,14 +385,18 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
+          let updateProgress = 0;
           const results = await withConcurrency(
-            updates.map((u: any) => () => {
+            updates.map((u: any) => async () => {
               const { id, ...fields } = u;
               const updateFields: Record<string, any> = {};
               for (const [key, value] of Object.entries(fields)) {
                 if (UPDATE_FIELDS.has(key) && value !== undefined) updateFields[key] = value;
               }
-              return makeRequest('PATCH', `/v1/memories/${id}`, updateFields);
+              const result = await makeRequest('PATCH', `/v1/memories/${id}`, updateFields);
+              updateProgress++;
+              await progress(updateProgress, updates.length);
+              return result;
             }),
             10
           );

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -23,7 +23,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       });
       const memories = result.memories || [];
       if (memories.length === 0) {
-        return { content: [userText(`No memories found for query: "${query}"`, 0.3)] };
+        return { content: [userText(`No memories found for query: "${query}"`, 0.3)], structuredContent: { memories: [] } };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
       return {
@@ -53,7 +53,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('GET', `/v1/memories/search?${params}`);
       const memories = result.memories || result.data || [];
       if (memories.length === 0) {
-        return { content: [userText(`No memories found containing: "${query}"`, 0.3)] };
+        return { content: [userText(`No memories found containing: "${query}"`, 0.3)], structuredContent: { memories: [] } };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
       return {
@@ -78,7 +78,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('POST', '/v1/context', body);
       const memories = result.memories || result.context || [];
       if (memories.length === 0) {
-        return { content: [userText(`No relevant context found for: "${query}"`, 0.3)] };
+        return { content: [userText(`No relevant context found for: "${query}"`, 0.3)], structuredContent: { memories: [] } };
       }
       const formatted = memories.map((m: any) => formatMemory(m)).join('\n\n');
       return {
@@ -102,7 +102,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       const result = await makeRequest('GET', `/v1/suggested${qs ? '?' + qs : ''}`);
       const suggestions = result.suggestions || result.memories || [];
       if (suggestions.length === 0) {
-        return { content: [userText(`No suggestions found${category ? ` for category "${category}"` : ''}.`, 0.3)] };
+        return { content: [userText(`No suggestions found${category ? ` for category "${category}"` : ''}.`, 0.3)], structuredContent: { suggestions: [] } };
       }
       const formatted = suggestions.map((m: any) => formatMemory(m)).join('\n\n');
       return {

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -30,7 +30,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const result = await makeRequest('GET', `/v1/memories/${memory_id}/relations`);
       const relations = result.relations || [];
       if (relations.length === 0) {
-        return { content: [userText(`No relations found for memory ${memory_id}.`, 0.3)] };
+        return { content: [userText(`No relations found for memory ${memory_id}.`, 0.3)], structuredContent: { relations: [] } };
       }
       const formatted = relations.map((r: any) =>
         `🔗 ${r.id || '?'}: ${r.source_id || memory_id} —[${r.relation_type}]→ ${r.target_id}`

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -35,18 +35,27 @@ export type ToolResult = { content: ContentItem[]; isError?: boolean; structured
 
 export type ToolHandler = (name: string, args: any) => Promise<ToolResult>;
 
+/**
+ * Progress callback for long-running operations.
+ * Wraps server.sendProgress() — only emits if the client provided a progressToken.
+ */
+export type ProgressCallback = (current: number, total: number) => Promise<void>;
+
 export interface HandlerContext {
   api: ApiClient;
   config: Config;
   makeRequest: ApiClient['makeRequest'];
   account: ApiClient['account'];
+  /** Report progress for long-running operations. No-op if client didn't provide a progressToken. */
+  progress: ProgressCallback;
 }
 
-export function createContext(api: ApiClient, config: Config): HandlerContext {
+export function createContext(api: ApiClient, config: Config, progress?: ProgressCallback): HandlerContext {
   return {
     api,
     config,
     makeRequest: api.makeRequest,
     account: api.account,
+    progress: progress || (async () => {}),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import type { LogLevel } from './logging.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let VERSION = '1.15.0';
+let VERSION = '1.16.0';
 try {
   const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
   VERSION = pkg.version;
@@ -138,10 +138,26 @@ server.setRequestHandler(SetLevelRequestSchema, async (request) => {
 
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
+  const { name, arguments: args, _meta } = request.params;
   mcpLogger.debug('tool', { event: 'call', tool: name, args });
+
+  // Extract progressToken from _meta (MCP spec: optional progress reporting)
+  const progressToken = _meta?.progressToken;
+  const progress = progressToken
+    ? async (current: number, total: number) => {
+        try {
+          await server.notification({
+            method: 'notifications/progress' as const,
+            params: { progressToken, progress: current, total },
+          });
+        } catch {
+          // Don't let progress notification failures break the tool call
+        }
+      }
+    : undefined;
+
   try {
-    const result = await handleToolCall(name, args as any);
+    const result = await handleToolCall(name, args as any, progress);
     mcpLogger.debug('tool', { event: 'success', tool: name });
     return result;
   } catch (error) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -824,7 +824,7 @@ export const TOOLS = [
       type: 'object' as const,
       properties: {
         memory_id: { type: 'string', description: 'Starting memory ID.' },
-        depth: { type: 'number', description: 'Hops to traverse. Default: 1. Max: 3.' },
+        depth: { type: 'number', minimum: 1, maximum: 3, description: 'Hops to traverse. Default: 1. Max: 3.' },
         relation_type: { type: 'string', enum: ['related_to', 'derived_from', 'contradicts', 'supersedes', 'supports'], description: 'Only follow this relation type.' },
       },
       required: ['memory_id'],

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for MCP progress notifications in long-running handlers.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHandler } from '../src/handlers/index.js';
+import type { ProgressCallback } from '../src/handlers/types.js';
+
+// Mock API client
+function createMockApi(responses: Record<string, any> = {}) {
+  const calls: Array<{ method: string; path: string; body?: any }> = [];
+  return {
+    makeRequest: vi.fn(async (method: string, path: string, body?: any) => {
+      calls.push({ method, path, body });
+      // Route responses by path pattern
+      if (path.includes('/v1/free-tier/status')) return { free_tier_remaining: 50, free_tier_total: 100, wallet: '0xtest' };
+      if (path.includes('/v1/store/batch')) throw new Error('404 Not Found');
+      if (path.includes('/v1/store')) return { memory: { id: `mem-${calls.length}`, content: 'test' } };
+      if (path.includes('/v1/memories/bulk-delete')) throw new Error('404 Not Found');
+      if (path.includes('/v1/memories/batch-update')) throw new Error('404 Not Found');
+      if (path.match(/DELETE.*\/v1\/memories\//)) return { deleted: true };
+      if (path.match(/PATCH.*\/v1\/memories\//) || path.includes('/v1/memories/') && method === 'PATCH') return { memory: { id: 'test', content: 'updated' } };
+      if (path.includes('/v1/memories') && method === 'GET') {
+        // For delete_namespace — return memories once, then empty
+        if (responses._namespaceMemories) {
+          const mems = responses._namespaceMemories;
+          responses._namespaceMemories = null;
+          return { memories: mems, total: mems.length };
+        }
+        return { memories: [], total: 0 };
+      }
+      return responses[path] || {};
+    }),
+    account: { address: '0xtest' },
+    calls,
+  };
+}
+
+const mockConfig = {
+  privateKey: '0x' + 'a'.repeat(64),
+  apiUrl: 'https://api.memoclaw.com',
+  configSource: 'test',
+  timeout: 5000,
+  maxRetries: 0,
+};
+
+describe('progress notifications', () => {
+  describe('bulk_store fallback (one-by-one)', () => {
+    it('calls progress callback for each stored memory', async () => {
+      const api = createMockApi();
+      const handler = createHandler(api as any, mockConfig);
+      const progressCalls: Array<[number, number]> = [];
+      const progress: ProgressCallback = async (current, total) => {
+        progressCalls.push([current, total]);
+      };
+
+      await handler('memoclaw_bulk_store', {
+        memories: [
+          { content: 'memory 1' },
+          { content: 'memory 2' },
+          { content: 'memory 3' },
+        ],
+      }, progress);
+
+      expect(progressCalls.length).toBe(3);
+      expect(progressCalls[progressCalls.length - 1]).toEqual([3, 3]);
+    });
+  });
+
+  describe('bulk_delete fallback (one-by-one)', () => {
+    it('calls progress callback for each deleted memory', async () => {
+      const api = createMockApi();
+      const handler = createHandler(api as any, mockConfig);
+      const progressCalls: Array<[number, number]> = [];
+      const progress: ProgressCallback = async (current, total) => {
+        progressCalls.push([current, total]);
+      };
+
+      await handler('memoclaw_bulk_delete', {
+        ids: ['id-1', 'id-2', 'id-3'],
+      }, progress);
+
+      expect(progressCalls.length).toBe(3);
+      expect(progressCalls[progressCalls.length - 1]).toEqual([3, 3]);
+    });
+  });
+
+  describe('batch_update fallback (one-by-one)', () => {
+    it('calls progress callback for each updated memory', async () => {
+      const api = createMockApi();
+      const handler = createHandler(api as any, mockConfig);
+      const progressCalls: Array<[number, number]> = [];
+      const progress: ProgressCallback = async (current, total) => {
+        progressCalls.push([current, total]);
+      };
+
+      await handler('memoclaw_batch_update', {
+        updates: [
+          { id: 'id-1', importance: 0.9 },
+          { id: 'id-2', importance: 0.8 },
+        ],
+      }, progress);
+
+      expect(progressCalls.length).toBe(2);
+      expect(progressCalls[progressCalls.length - 1]).toEqual([2, 2]);
+    });
+  });
+
+  describe('delete_namespace', () => {
+    it('calls progress callback during namespace deletion', async () => {
+      const api = createMockApi({
+        _namespaceMemories: [
+          { id: 'ns-1', content: 'test1' },
+          { id: 'ns-2', content: 'test2' },
+        ],
+      });
+      const handler = createHandler(api as any, mockConfig);
+      const progressCalls: Array<[number, number]> = [];
+      const progress: ProgressCallback = async (current, total) => {
+        progressCalls.push([current, total]);
+      };
+
+      await handler('memoclaw_delete_namespace', {
+        namespace: 'test-ns',
+      }, progress);
+
+      expect(progressCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('without progress callback', () => {
+    it('works normally when no progress callback is provided', async () => {
+      const api = createMockApi();
+      const handler = createHandler(api as any, mockConfig);
+
+      // Should not throw
+      const result = await handler('memoclaw_bulk_store', {
+        memories: [{ content: 'test' }],
+      });
+
+      expect(result.content.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('structuredContent on empty results', () => {
+  function createEmptyApi() {
+    return {
+      makeRequest: vi.fn(async () => ({ memories: [], relations: [], suggestions: [] })),
+      account: { address: '0xtest' },
+    };
+  }
+
+  it('memoclaw_recall returns structuredContent on empty results', async () => {
+    const api = createEmptyApi();
+    const handler = createHandler(api as any, mockConfig);
+    const result = await handler('memoclaw_recall', { query: 'test' });
+    expect(result.structuredContent).toEqual({ memories: [] });
+  });
+
+  it('memoclaw_search returns structuredContent on empty results', async () => {
+    const api = createEmptyApi();
+    const handler = createHandler(api as any, mockConfig);
+    const result = await handler('memoclaw_search', { query: 'test' });
+    expect(result.structuredContent).toEqual({ memories: [] });
+  });
+
+  it('memoclaw_context returns structuredContent on empty results', async () => {
+    const api = createEmptyApi();
+    api.makeRequest = vi.fn(async () => ({ memories: [] }));
+    const handler = createHandler(api as any, mockConfig);
+    const result = await handler('memoclaw_context', { query: 'test' });
+    expect(result.structuredContent).toEqual({ memories: [] });
+  });
+
+  it('memoclaw_suggested returns structuredContent on empty results', async () => {
+    const api = createEmptyApi();
+    const handler = createHandler(api as any, mockConfig);
+    const result = await handler('memoclaw_suggested', {});
+    expect(result.structuredContent).toEqual({ suggestions: [] });
+  });
+
+  it('memoclaw_list_relations returns structuredContent on empty results', async () => {
+    const api = createEmptyApi();
+    const handler = createHandler(api as any, mockConfig);
+    const result = await handler('memoclaw_list_relations', { memory_id: 'test-id' });
+    expect(result.structuredContent).toEqual({ relations: [] });
+  });
+});


### PR DESCRIPTION
## Summary

Implements MCP progress notifications (`notifications/progress`) for long-running operations, per the [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/progress). Also fixes inconsistent `structuredContent` on empty results and adds schema constraints.

Fixes #110

## Changes

### Progress notifications
- Extract `_meta.progressToken` from tool call requests in `index.ts`
- Pass a `ProgressCallback` through `HandlerContext` to all handlers
- Emit progress in fallback (one-by-one) paths of:
  - `memoclaw_bulk_store` — reports N/total as each memory is stored
  - `memoclaw_bulk_delete` — reports deletion progress
  - `memoclaw_batch_update` — reports update progress
  - `memoclaw_delete_namespace` — reports pages processed
  - `memoclaw_export` (fallback) — reports pagination progress
  - `memoclaw_migrate` (fallback) — reports files processed
  - `memoclaw_import` (fallback) — reports import progress
- No-op when client doesn't provide a progressToken (backward compatible)

### Bug fixes
- **Missing `structuredContent` on empty results** — `memoclaw_recall`, `memoclaw_search`, `memoclaw_context`, `memoclaw_suggested`, and `memoclaw_list_relations` now return `structuredContent` even when no matches are found, ensuring clients parsing structured output always get a predictable shape
- **Schema constraint** — Added `minimum: 1` and `maximum: 3` to `depth` parameter in `memoclaw_graph` input schema (handler already clamped to 1-3)

### Tests
- 10 new tests covering progress callbacks for bulk operations and empty-result `structuredContent`
- All 419 tests pass

### Version
- Bumped to v1.16.0