### PR TITLE
feat: add server instructions and input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-03-08
+
+### Added
+- Server `instructions` field in MCP InitializeResult (Fixes #115)
+  - Provides LLMs with a concise description of MemoClaw capabilities and constraints
+  - Improves tool discovery for MCP clients that surface instructions in system prompts
+- Input validation module (`src/validate.ts`) with helpers for identifiers, IDs, tags, and queries (Fixes #117)
+  - `validateIdentifier()` — enforces length limits (256 chars) and safe character set for namespace, session_id, agent_id, memory_type, relation_type
+  - `validateId()` — ensures IDs are non-empty strings within length limits
+  - `validateTags()` — validates tag arrays (max 50 tags, 128 chars each, no empty strings)
+  - `validateQuery()` — ensures query strings are non-empty
+- 16 new tests for the validation module
+
+### Changed
+- All handlers now validate string parameters client-side before making API calls
+  - Faster feedback for invalid input (no network roundtrip needed)
+  - Clear, descriptive error messages for each parameter
+
 ## [1.16.0] - 2026-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, extname, basename } from 'node:path';
 import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
+import { validateIdentifier, validateId } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
@@ -70,6 +71,9 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
     case 'memoclaw_ingest': {
       const { messages, text, namespace, session_id, agent_id, auto_relate } = args as IngestArgs;
       if (!messages && !text) throw new Error('Either messages or text is required');
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const result = await makeRequest('POST', '/v1/ingest', {
         messages, text, namespace, session_id, agent_id, auto_relate: auto_relate !== false,
       });
@@ -277,7 +281,9 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_delete_namespace': {
       const { namespace, agent_id } = args as DeleteNamespaceArgs;
+      validateIdentifier(namespace, 'namespace');
       if (!namespace) throw new Error('namespace is required');
+      validateIdentifier(agent_id, 'agent_id');
       const deletedIds: string[] = [];
       const errors: string[] = [];
       const failedIds = new Set<string>();
@@ -370,7 +376,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_history': {
       const { id } = args as HistoryArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const result = await makeRequest('GET', `/v1/memories/${id}/history`);
       const history = result.history || result.versions || result.data || [];
       if (history.length === 0) {

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -1,4 +1,5 @@
 import { formatMemory, withConcurrency, validateContentLength, validateImportance, UPDATE_FIELDS, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
+import { validateIdentifier, validateId, validateTags } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StoreArgs, GetArgs, ListArgs, UpdateArgs, DeleteArgs,
@@ -17,6 +18,11 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       }
       validateContentLength(content);
       validateImportance(importance);
+      validateTags(tags);
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(memory_type, 'memory_type');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const body: any = { content };
       if (importance !== undefined) body.importance = importance;
       if (tags) body.tags = tags;
@@ -41,7 +47,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_get': {
       const { id } = args as GetArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const result = await makeRequest('GET', `/v1/memories/${id}`);
       const memory = result.memory || result;
       return {
@@ -82,7 +88,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_update': {
       const { id, ...allFields } = args as UpdateArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const updateFields: Record<string, any> = {};
       for (const [key, value] of Object.entries(allFields)) {
         if (UPDATE_FIELDS.has(key) && value !== undefined) updateFields[key] = value;
@@ -106,7 +112,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_delete': {
       const { id } = args as DeleteArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const result = await makeRequest('DELETE', `/v1/memories/${id}`);
       return {
         content: [
@@ -330,7 +336,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_pin': {
       const { id } = args as PinArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: true });
       const memory = result.memory || result;
       return {
@@ -344,7 +350,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_unpin': {
       const { id } = args as UnpinArgs;
-      if (!id) throw new Error('id is required');
+      validateId(id, 'id');
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, { pinned: false });
       const memory = result.memory || result;
       return {

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -1,4 +1,5 @@
 import { formatMemory, userAndAssistantText, assistantText, userText } from '../format.js';
+import { validateIdentifier, validateTags, validateQuery } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs, CheckDuplicatesArgs } from '../types.js';
 
@@ -8,9 +9,12 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
   switch (name) {
     case 'memoclaw_recall': {
       const { query, limit, min_similarity, tags, namespace, memory_type, session_id, agent_id, include_relations, after, before } = args as RecallArgs;
-      if (!query || (typeof query === 'string' && query.trim() === '')) {
-        throw new Error('query is required and cannot be empty');
-      }
+      validateQuery(query);
+      validateTags(tags);
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(memory_type, 'memory_type');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const filters: Record<string, any> = {};
       if (tags) filters.tags = tags;
       if (memory_type) filters.memory_type = memory_type;
@@ -37,9 +41,12 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_search': {
       const { query, limit, namespace, tags, memory_type, session_id, agent_id, after, before } = args as SearchArgs;
-      if (!query || (typeof query === 'string' && query.trim() === '')) {
-        throw new Error('query is required and cannot be empty');
-      }
+      validateQuery(query);
+      validateIdentifier(namespace, 'namespace');
+      validateTags(tags);
+      validateIdentifier(memory_type, 'memory_type');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const params = new URLSearchParams();
       params.set('q', query);
       if (limit !== undefined) params.set('limit', String(limit));
@@ -67,9 +74,10 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_context': {
       const { query, limit, namespace, session_id, agent_id } = args as ContextArgs;
-      if (!query || (typeof query === 'string' && query.trim() === '')) {
-        throw new Error('query is required and cannot be empty');
-      }
+      validateQuery(query);
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const body: any = { query };
       if (limit !== undefined) body.limit = limit;
       if (namespace) body.namespace = namespace;
@@ -119,6 +127,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (!content || (typeof content === 'string' && content.trim() === '')) {
         throw new Error('content is required and cannot be empty');
       }
+      validateIdentifier(namespace, 'namespace');
       const threshold = min_similarity ?? 0.7;
       const maxResults = limit ?? 5;
       const body: any = { query: content, limit: maxResults, min_similarity: threshold };

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,4 +1,5 @@
 import { formatMemory, withConcurrency, userAndAssistantText, assistantText, userText } from '../format.js';
+import { validateId, validateIdentifier } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { CreateRelationArgs, ListRelationsArgs, DeleteRelationArgs, GraphArgs } from '../types.js';
 
@@ -8,9 +9,10 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
   switch (name) {
     case 'memoclaw_create_relation': {
       const { memory_id, target_id, relation_type, metadata } = args as CreateRelationArgs;
-      if (!memory_id || !target_id || !relation_type) {
-        throw new Error('memory_id, target_id, and relation_type are all required');
-      }
+      validateId(memory_id, 'memory_id');
+      validateId(target_id, 'target_id');
+      validateIdentifier(relation_type, 'relation_type');
+      if (!relation_type) throw new Error('relation_type is required');
       const body: any = { target_id, relation_type };
       if (metadata) body.metadata = metadata;
       const result = await makeRequest('POST', `/v1/memories/${memory_id}/relations`, body);
@@ -26,7 +28,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
     case 'memoclaw_list_relations': {
       const { memory_id } = args as ListRelationsArgs;
-      if (!memory_id) throw new Error('memory_id is required');
+      validateId(memory_id, 'memory_id');
       const result = await makeRequest('GET', `/v1/memories/${memory_id}/relations`);
       const relations = result.relations || [];
       if (relations.length === 0) {
@@ -46,7 +48,8 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
     case 'memoclaw_delete_relation': {
       const { memory_id, relation_id } = args as DeleteRelationArgs;
-      if (!memory_id || !relation_id) throw new Error('memory_id and relation_id are required');
+      validateId(memory_id, 'memory_id');
+      validateId(relation_id, 'relation_id');
       const result = await makeRequest('DELETE', `/v1/memories/${memory_id}/relations/${relation_id}`);
       return {
         content: [
@@ -59,7 +62,8 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
 
     case 'memoclaw_graph': {
       const { memory_id, depth: rawDepth, relation_type } = args as GraphArgs;
-      if (!memory_id) throw new Error('memory_id is required');
+      validateId(memory_id, 'memory_id');
+      if (relation_type) validateIdentifier(relation_type, 'relation_type');
       const depth = Math.min(Math.max(rawDepth || 1, 1), 3);
       const visited = new Set<string>();
       const nodes: any[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import type { LogLevel } from './logging.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let VERSION = '1.16.0';
+let VERSION = '1.17.0';
 try {
   const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
   VERSION = pkg.version;
@@ -78,9 +78,24 @@ const handleReadResource = createResourceHandler(api, config);
 const handleGetPrompt = createPromptHandler(api, config);
 const handleComplete = createCompletionHandler(api, config);
 
+const SERVER_INSTRUCTIONS = [
+  'MemoClaw is a semantic memory service for AI agents.',
+  'Store, recall, search, and manage memories with vector search.',
+  'Key constraints: max 8192 chars per memory, importance must be 0.0–1.0.',
+  'Identity is wallet-based — no API keys or registration needed.',
+  'Free tier: 100 API calls per wallet, then pay-per-use via x402 (USDC on Base).',
+  'Use memoclaw_recall for semantic search, memoclaw_search for text/substring search.',
+  'Use namespaces to isolate memories per project or context.',
+  'Pin important memories, set immutable to lock from edits.',
+  'Check duplicates before storing with memoclaw_check_duplicates.',
+].join(' ');
+
 const server = new Server(
   { name: 'memoclaw', version: VERSION },
-  { capabilities: { tools: {}, resources: {}, prompts: {}, completions: {}, logging: {} } }
+  {
+    capabilities: { tools: {}, resources: {}, prompts: {}, completions: {}, logging: {} },
+    instructions: SERVER_INSTRUCTIONS,
+  }
 );
 
 // Attach logger to server for sending notifications to clients

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,86 @@
+/**
+ * Input validation helpers for MCP tool arguments.
+ *
+ * Provides fast client-side validation with clear error messages,
+ * reducing unnecessary API round-trips for obviously invalid input.
+ */
+
+/** Maximum length for string identifiers (namespace, session_id, agent_id, etc.) */
+const MAX_IDENTIFIER_LENGTH = 256;
+
+/** Maximum length for tag strings */
+const MAX_TAG_LENGTH = 128;
+
+/** Maximum number of tags per memory */
+const MAX_TAGS_COUNT = 50;
+
+/** Allowed characters for identifiers: alphanumeric, dash, underscore, dot, colon */
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9_\-.:@]+$/;
+
+/**
+ * Validate a string identifier parameter (namespace, session_id, agent_id, relation_type).
+ * Returns undefined if value is falsy (optional params), throws on invalid.
+ */
+export function validateIdentifier(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`);
+  }
+  if (value.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`${label} exceeds ${MAX_IDENTIFIER_LENGTH} character limit (got ${value.length})`);
+  }
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    throw new Error(
+      `${label} contains invalid characters. Allowed: letters, numbers, dash, underscore, dot, colon, @`
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate an ID parameter (memory ID, relation ID).
+ * Must be a non-empty string. Does not enforce UUID format since the API
+ * may use other ID schemes.
+ */
+export function validateId(value: unknown, label = 'id'): string {
+  if (!value || typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${label} is required and must be a non-empty string`);
+  }
+  if (value.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`${label} exceeds ${MAX_IDENTIFIER_LENGTH} character limit`);
+  }
+  return value;
+}
+
+/**
+ * Validate a tags array. Each tag must be a non-empty string within length limits.
+ */
+export function validateTags(tags: unknown, label = 'tags'): string[] | undefined {
+  if (tags === undefined || tags === null) return undefined;
+  if (!Array.isArray(tags)) {
+    throw new Error(`${label} must be an array of strings`);
+  }
+  if (tags.length > MAX_TAGS_COUNT) {
+    throw new Error(`${label} exceeds maximum of ${MAX_TAGS_COUNT} tags (got ${tags.length})`);
+  }
+  for (let i = 0; i < tags.length; i++) {
+    const tag = tags[i];
+    if (typeof tag !== 'string' || tag.trim() === '') {
+      throw new Error(`${label}[${i}] must be a non-empty string`);
+    }
+    if (tag.length > MAX_TAG_LENGTH) {
+      throw new Error(`${label}[${i}] exceeds ${MAX_TAG_LENGTH} character limit (got ${tag.length})`);
+    }
+  }
+  return tags as string[];
+}
+
+/**
+ * Validate a query string parameter. Must be non-empty after trimming.
+ */
+export function validateQuery(value: unknown, label = 'query'): string {
+  if (!value || typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${label} is required and cannot be empty`);
+  }
+  return value;
+}

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { validateIdentifier, validateId, validateTags, validateQuery } from '../src/validate.js';
+
+describe('validateIdentifier', () => {
+  it('returns undefined for undefined/null/empty', () => {
+    expect(validateIdentifier(undefined, 'ns')).toBeUndefined();
+    expect(validateIdentifier(null, 'ns')).toBeUndefined();
+    expect(validateIdentifier('', 'ns')).toBeUndefined();
+  });
+
+  it('accepts valid identifiers', () => {
+    expect(validateIdentifier('default', 'ns')).toBe('default');
+    expect(validateIdentifier('my-project', 'ns')).toBe('my-project');
+    expect(validateIdentifier('agent_123', 'ns')).toBe('agent_123');
+    expect(validateIdentifier('ns.sub', 'ns')).toBe('ns.sub');
+    expect(validateIdentifier('user:abc', 'ns')).toBe('user:abc');
+    expect(validateIdentifier('user@agent', 'ns')).toBe('user@agent');
+  });
+
+  it('rejects non-string values', () => {
+    expect(() => validateIdentifier(123, 'ns')).toThrow('must be a string');
+    expect(() => validateIdentifier(true, 'ns')).toThrow('must be a string');
+  });
+
+  it('rejects identifiers exceeding length limit', () => {
+    const long = 'a'.repeat(257);
+    expect(() => validateIdentifier(long, 'ns')).toThrow('exceeds 256 character limit');
+  });
+
+  it('rejects identifiers with invalid characters', () => {
+    expect(() => validateIdentifier('has space', 'ns')).toThrow('invalid characters');
+    expect(() => validateIdentifier('has/slash', 'ns')).toThrow('invalid characters');
+    expect(() => validateIdentifier('has<html>', 'ns')).toThrow('invalid characters');
+    expect(() => validateIdentifier('emoji🎉', 'ns')).toThrow('invalid characters');
+  });
+});
+
+describe('validateId', () => {
+  it('accepts valid IDs', () => {
+    expect(validateId('abc-123')).toBe('abc-123');
+    expect(validateId('550e8400-e29b-41d4-a716-446655440000')).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('rejects empty/missing IDs', () => {
+    expect(() => validateId(undefined)).toThrow('required');
+    expect(() => validateId(null)).toThrow('required');
+    expect(() => validateId('')).toThrow('required');
+    expect(() => validateId('   ')).toThrow('required');
+  });
+
+  it('rejects IDs exceeding length limit', () => {
+    const long = 'x'.repeat(257);
+    expect(() => validateId(long)).toThrow('exceeds 256 character limit');
+  });
+});
+
+describe('validateTags', () => {
+  it('returns undefined for undefined/null', () => {
+    expect(validateTags(undefined)).toBeUndefined();
+    expect(validateTags(null)).toBeUndefined();
+  });
+
+  it('accepts valid tag arrays', () => {
+    expect(validateTags(['bug', 'feature'])).toEqual(['bug', 'feature']);
+    expect(validateTags([])).toEqual([]);
+  });
+
+  it('rejects non-array', () => {
+    expect(() => validateTags('not-array')).toThrow('must be an array');
+  });
+
+  it('rejects arrays with too many tags', () => {
+    const many = Array.from({ length: 51 }, (_, i) => `tag${i}`);
+    expect(() => validateTags(many)).toThrow('exceeds maximum of 50 tags');
+  });
+
+  it('rejects empty string tags', () => {
+    expect(() => validateTags(['good', ''])).toThrow('tags[1] must be a non-empty string');
+  });
+
+  it('rejects tags exceeding length limit', () => {
+    const longTag = 'x'.repeat(129);
+    expect(() => validateTags([longTag])).toThrow('exceeds 128 character limit');
+  });
+});
+
+describe('validateQuery', () => {
+  it('accepts valid queries', () => {
+    expect(validateQuery('search term')).toBe('search term');
+  });
+
+  it('rejects empty/missing queries', () => {
+    expect(() => validateQuery(undefined)).toThrow('required');
+    expect(() => validateQuery('')).toThrow('required');
+    expect(() => validateQuery('   ')).toThrow('required');
+  });
+});


### PR DESCRIPTION
## Summary
Two improvements bundled together:

### 1. Server Instructions (Fixes #115)
Added the MCP `instructions` field to the server's `InitializeResult`. This gives LLMs a concise description of MemoClaw's capabilities, key constraints (8192 char limit, importance 0-1), and usage tips when they connect.

### 2. Input Validation (Fixes #117)  
Added a `src/validate.ts` module with four helpers:
- `validateIdentifier()` — enforces 256 char limit and safe character set (`[a-zA-Z0-9_\-.:@]`) for namespace, session_id, agent_id, memory_type, relation_type
- `validateId()` — ensures IDs are non-empty strings within length limits
- `validateTags()` — validates tag arrays (max 50 tags, 128 chars each, no empty strings)  
- `validateQuery()` — ensures query strings are non-empty

Applied across all handlers (memory, recall, relations, admin). This catches invalid input before making API calls — faster feedback, clearer errors.

### Tests
- 16 new tests for the validation module
- All 435 tests pass
- Build clean

### Version
Bumped to 1.17.0