### PR TITLE
feat: support MCP cancellation for long-running operations

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -24,12 +24,16 @@ export function formatMemory(m: any): string {
 
 /**
  * Run promises with concurrency limit.
+ * If an AbortSignal is provided and aborted, remaining tasks are skipped
+ * and the returned array will contain results only for tasks that started.
  */
-export async function withConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): Promise<PromiseSettledResult<T>[]> {
+export async function withConcurrency<T>(tasks: (() => Promise<T>)[], limit: number, signal?: AbortSignal): Promise<PromiseSettledResult<T>[]> {
   const results: PromiseSettledResult<T>[] = new Array(tasks.length);
   let idx = 0;
+  let cancelled = false;
   async function worker() {
     while (idx < tasks.length) {
+      if (signal?.aborted) { cancelled = true; return; }
       const i = idx++;
       try {
         results[i] = { status: 'fulfilled', value: await tasks[i]() };
@@ -40,6 +44,10 @@ export async function withConcurrency<T>(tasks: (() => Promise<T>)[], limit: num
   }
   const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
   await Promise.all(workers);
+  // If cancelled, trim results to only include started tasks
+  if (cancelled) {
+    return results.slice(0, idx);
+  }
   return results;
 }
 

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -3,6 +3,7 @@ import { join, extname, basename } from 'node:path';
 import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
 import { validateIdentifier, validateId } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
+import { throwIfCancelled, CancellationError } from './types.js';
 import type {
   StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
   ExportArgs, MigrateArgs, DeleteNamespaceArgs, TagsArgs, HistoryArgs,
@@ -10,7 +11,7 @@ import type {
 } from '../types.js';
 
 export async function handleAdmin(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest, account, config, progress } = ctx;
+  const { makeRequest, account, config, progress, signal } = ctx;
 
   switch (name) {
     case 'memoclaw_status': {
@@ -154,7 +155,9 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         let offset = 0;
         const pageSize = 100;
         let exportPage = 0;
+        let exportCancelled = false;
         while (true) {
+          if (signal.aborted) { exportCancelled = true; break; }
           exportPage++;
           const fallbackParams = new URLSearchParams();
           fallbackParams.set('limit', String(pageSize));
@@ -171,12 +174,13 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const output = fmt === 'jsonl'
           ? allMemories.map((m: any) => JSON.stringify(m)).join('\n')
           : JSON.stringify(allMemories, null, 2);
+        const exportPrefix = exportCancelled ? '⚠️ Export cancelled — partial result' : '📦 Exported';
         return {
           content: [
-            userAndAssistantText(`📦 Exported ${allMemories.length} memories`),
+            userAndAssistantText(`${exportPrefix}: ${allMemories.length} memories`),
             assistantText(output),
           ],
-          structuredContent: { memories: allMemories, count: allMemories.length },
+          structuredContent: { memories: allMemories, count: allMemories.length, cancelled: exportCancelled },
         };
       }
     }
@@ -253,8 +257,11 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
             };
           }
           let totalCreated = 0;
+          let filesProcessed = 0;
           const errors: string[] = [];
+          let migrateCancelled = false;
           for (let fi = 0; fi < fileList.length; fi++) {
+            if (signal.aborted) { migrateCancelled = true; break; }
             const file = fileList[fi];
             try {
               const r = await makeRequest('POST', '/v1/ingest', {
@@ -266,13 +273,17 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
             } catch (e: any) {
               errors.push(`${file.filename}: ${e.message}`);
             }
+            filesProcessed++;
             await progress(fi + 1, fileList.length);
           }
-          let text = `✅ Migration complete (via ingest fallback)\n\n📁 Files processed: ${fileList.length}\n📝 Memories created: ${totalCreated}`;
+          const migratePrefix = migrateCancelled
+            ? `⚠️ Migration cancelled after ${filesProcessed} of ${fileList.length} files (via ingest fallback)`
+            : `✅ Migration complete (via ingest fallback)\n\n📁 Files processed: ${fileList.length}`;
+          let text = `${migratePrefix}\n📝 Memories created: ${totalCreated}`;
           if (errors.length > 0) text += `\n\n❌ Errors:\n${errors.join('\n')}`;
           return {
             content: [userAndAssistantText(text)],
-            structuredContent: { files_processed: fileList.length, memories_created: totalCreated, duplicates_skipped: 0, memories: [] },
+            structuredContent: { files_processed: filesProcessed, memories_created: totalCreated, duplicates_skipped: 0, memories: [], cancelled: migrateCancelled },
           };
         }
         throw err;
@@ -289,8 +300,10 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const failedIds = new Set<string>();
       let pages = 0;
       const pageSize = 100;
+      let nsCancelled = false;
 
       while (pages < 200) {
+        if (signal.aborted) { nsCancelled = true; break; }
         pages++;
         const params = new URLSearchParams();
         params.set('limit', String(pageSize));
@@ -304,10 +317,12 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (toDelete.length === 0) break;
         const deleteResults = await withConcurrency(
           toDelete.map((m: any) => () => makeRequest('DELETE', `/v1/memories/${m.id}`)),
-          10
+          10,
+          signal
         );
         let pageSuccesses = 0;
         for (let i = 0; i < deleteResults.length; i++) {
+          if (!deleteResults[i]) continue; // skipped due to cancellation
           if (deleteResults[i].status === 'fulfilled') {
             deletedIds.push(toDelete[i].id);
             pageSuccesses++;
@@ -317,15 +332,18 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
           }
         }
         await progress(deletedIds.length, deletedIds.length + (memories.length >= pageSize ? pageSize : 0));
+        if (signal.aborted) { nsCancelled = true; break; }
         if (memories.length < pageSize) break;
         if (pageSuccesses === 0) break;
       }
 
-      let text = `🗑️ Namespace "${namespace}": ${deletedIds.length} memories deleted`;
+      const nsPrefix = nsCancelled ? '⚠️ Cancelled — partial deletion' : '🗑️';
+      let text = `${nsPrefix} Namespace "${namespace}": ${deletedIds.length} memories deleted`;
+      if (nsCancelled) text += ` before cancellation`;
       if (errors.length > 0) text += `, ${errors.length} failed\n\nErrors:\n${errors.slice(0, 10).join('\n')}`;
       return {
         content: [userAndAssistantText(text)],
-        structuredContent: { deleted: deletedIds.length, failed: errors.length, namespace, errors: errors.slice(0, 10) },
+        structuredContent: { deleted: deletedIds.length, failed: errors.length, namespace, errors: errors.slice(0, 10), cancelled: nsCancelled },
       };
     }
 
@@ -352,6 +370,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       let offset = 0;
       const pageSize = 100;
       for (let page = 0; page < 200; page++) {
+        if (signal.aborted) break;
         const params = new URLSearchParams();
         params.set('limit', String(pageSize));
         params.set('offset', String(offset));
@@ -427,6 +446,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       let offset = 0;
       const pageSize = 100;
       for (let page = 0; page < 200; page++) {
+        if (signal.aborted) break;
         const params = new URLSearchParams();
         params.set('limit', String(pageSize));
         params.set('offset', String(offset));

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -10,8 +10,8 @@ import { handleAdmin } from './admin.js';
 export type { ToolResult };
 
 export function createHandler(api: ApiClient, config: Config) {
-  return async function handleToolCall(name: string, args: any, progress?: ProgressCallback): Promise<ToolResult> {
-    const ctx = createContext(api, config, progress);
+  return async function handleToolCall(name: string, args: any, progress?: ProgressCallback, signal?: AbortSignal): Promise<ToolResult> {
+    const ctx = createContext(api, config, progress, signal);
 
     // Try each domain handler in turn; first non-null result wins
     const result =

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -8,7 +8,7 @@ import type {
 } from '../types.js';
 
 export async function handleMemory(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest, progress } = ctx;
+  const { makeRequest, progress, signal } = ctx;
 
   switch (name) {
     case 'memoclaw_store': {
@@ -151,20 +151,24 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
             await progress(deleteProgress, ids.length);
             return result;
           }),
-          10
+          10,
+          signal
         );
-        succeeded = results.filter(r => r.status === 'fulfilled').length;
-        failed = results.filter(r => r.status === 'rejected').length;
+        succeeded = results.filter(r => r?.status === 'fulfilled').length;
+        failed = results.filter(r => r?.status === 'rejected').length;
         errors = results
-          .map((r, i) => r.status === 'rejected' ? `${ids[i]}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}` : null)
+          .map((r, i) => r?.status === 'rejected' ? `${ids[i]}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}` : null)
           .filter(Boolean) as string[];
       }
 
-      let text = `🗑️ Bulk delete: ${succeeded} succeeded, ${failed} failed`;
+      const bulkDeleteCancelled = signal.aborted && (succeeded + failed) < ids.length;
+      let text = bulkDeleteCancelled
+        ? `⚠️ Bulk delete cancelled: ${succeeded} of ${ids.length} succeeded, ${failed} failed`
+        : `🗑️ Bulk delete: ${succeeded} succeeded, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
       return {
         content: [userAndAssistantText(text)],
-        structuredContent: { succeeded, failed, errors },
+        structuredContent: { succeeded, failed, errors, cancelled: bulkDeleteCancelled },
       };
     }
 
@@ -233,22 +237,26 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           await progress(storeProgress, memories.length);
           return result;
         }),
-        10
+        10,
+        signal
       );
-      const succeeded = results.filter(r => r.status === 'fulfilled');
-      const failed = results.filter(r => r.status === 'rejected');
+      const succeeded = results.filter(r => r?.status === 'fulfilled');
+      const failed = results.filter(r => r?.status === 'rejected');
       const stored = succeeded.map(r => (r as PromiseFulfilledResult<any>).value?.memory || (r as PromiseFulfilledResult<any>).value);
       const errors = failed.map((r) => {
         const idx = results.indexOf(r);
         return `index ${idx}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}`;
       });
-      let text = `✅ Bulk store: ${succeeded.length} stored, ${failed.length} failed`;
+      const bulkStoreCancelled = signal.aborted && (succeeded.length + failed.length) < memories.length;
+      let text = bulkStoreCancelled
+        ? `⚠️ Bulk store cancelled: ${succeeded.length} of ${memories.length} stored, ${failed.length} failed`
+        : `✅ Bulk store: ${succeeded.length} stored, ${failed.length} failed`;
       if (stored.length > 0) text += `\n\n${stored.map((m: any) => formatMemory(m)).join('\n\n')}`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
       const resourceLinks = stored.filter((m: any) => m?.id).map((m: any) => memoryResourceLink(m.id, 'Stored memory'));
       return {
         content: [userAndAssistantText(text), ...resourceLinks],
-        structuredContent: { succeeded: succeeded.length, failed: failed.length, memories: stored, errors },
+        structuredContent: { succeeded: succeeded.length, failed: failed.length, memories: stored, errors, cancelled: bulkStoreCancelled },
       };
     }
 
@@ -319,18 +327,22 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
           await progress(importProgress, memories.length);
           return result;
         }),
-        10
+        10,
+        signal
       );
-      const succeeded = results.filter(r => r.status === 'fulfilled').length;
-      const failed = results.filter(r => r.status === 'rejected').length;
+      const succeeded = results.filter(r => r?.status === 'fulfilled').length;
+      const failed = results.filter(r => r?.status === 'rejected').length;
       const errors = results
-        .map((r, i) => r.status === 'rejected' ? `index ${i}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}` : null)
+        .map((r, i) => r?.status === 'rejected' ? `index ${i}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}` : null)
         .filter(Boolean);
-      let text = `📥 Import: ${succeeded} stored, ${failed} failed`;
+      const importCancelled = signal.aborted && (succeeded + failed) < memories.length;
+      let text = importCancelled
+        ? `⚠️ Import cancelled: ${succeeded} of ${memories.length} stored, ${failed} failed`
+        : `📥 Import: ${succeeded} stored, ${failed} failed`;
       if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
       return {
         content: [userAndAssistantText(text)],
-        structuredContent: { succeeded, failed, errors },
+        structuredContent: { succeeded, failed, errors, cancelled: importCancelled },
       };
     }
 
@@ -404,24 +416,28 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
               await progress(updateProgress, updates.length);
               return result;
             }),
-            10
+            10,
+            signal
           );
-          const succeeded = results.filter(r => r.status === 'fulfilled');
-          const failed = results.filter(r => r.status === 'rejected');
+          const succeeded = results.filter(r => r?.status === 'fulfilled');
+          const failed = results.filter(r => r?.status === 'rejected');
           const memories = succeeded.map(r => (r as PromiseFulfilledResult<any>).value?.memory || (r as PromiseFulfilledResult<any>).value);
           const errors = failed.map((r) => {
             const idx = results.indexOf(r);
             return `${updates[idx]?.id}: ${(r as PromiseRejectedResult).reason?.message || 'unknown error'}`;
           });
-          let text = `✅ Batch update: ${succeeded.length} updated, ${failed.length} failed`;
+          const batchCancelled = signal.aborted && (succeeded.length + failed.length) < updates.length;
+          let text = batchCancelled
+            ? `⚠️ Batch update cancelled: ${succeeded.length} of ${updates.length} updated, ${failed.length} failed`
+            : `✅ Batch update: ${succeeded.length} updated, ${failed.length} failed`;
           if (memories.length > 0) text += `\n\n${memories.map((m: any) => formatMemory(m)).join('\n\n')}`;
           if (errors.length > 0) text += `\n\nErrors:\n${errors.join('\n')}`;
           const fallbackResourceLinks = updates
-            .filter((_u: any, i: number) => results[i].status === 'fulfilled')
+            .filter((_u: any, i: number) => results[i]?.status === 'fulfilled')
             .map((u: any) => memoryResourceLink(u.id, 'Updated memory'));
           return {
             content: [userAndAssistantText(text), ...fallbackResourceLinks],
-            structuredContent: { updated: succeeded.length, failed: failed.length, memories, errors },
+            structuredContent: { updated: succeeded.length, failed: failed.length, memories, errors, cancelled: batchCancelled },
           };
         }
         throw err;
@@ -455,6 +471,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
             let offset = 0;
             const pageSize = 100;
             while (offset < 10000) {
+              if (signal.aborted) break;
               const pageParams = new URLSearchParams(params);
               pageParams.set('limit', String(pageSize));
               pageParams.set('offset', String(offset));

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -48,14 +48,38 @@ export interface HandlerContext {
   account: ApiClient['account'];
   /** Report progress for long-running operations. No-op if client didn't provide a progressToken. */
   progress: ProgressCallback;
+  /** AbortSignal from the MCP protocol — aborted when the client sends notifications/cancelled. */
+  signal: AbortSignal;
 }
 
-export function createContext(api: ApiClient, config: Config, progress?: ProgressCallback): HandlerContext {
+/**
+ * Check if the operation has been cancelled and throw if so.
+ * Call this between iterations in long-running loops.
+ */
+export function throwIfCancelled(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new CancellationError();
+  }
+}
+
+/**
+ * Error thrown when a request is cancelled via MCP notifications/cancelled.
+ * Handlers should catch this to return partial results.
+ */
+export class CancellationError extends Error {
+  constructor() {
+    super('Operation cancelled by client');
+    this.name = 'CancellationError';
+  }
+}
+
+export function createContext(api: ApiClient, config: Config, progress?: ProgressCallback, signal?: AbortSignal): HandlerContext {
   return {
     api,
     config,
     makeRequest: api.makeRequest,
     account: api.account,
     progress: progress || (async () => {}),
+    signal: signal || new AbortController().signal,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ server.setRequestHandler(SetLevelRequestSchema, async (request) => {
 });
 
 // Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
   const { name, arguments: args, _meta } = request.params;
   mcpLogger.debug('tool', { event: 'call', tool: name, args });
 
@@ -171,8 +171,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
     : undefined;
 
+  // Pass the abort signal from the MCP protocol layer — it fires when the
+  // client sends notifications/cancelled for this request.
+  const signal = extra?.signal;
+
   try {
-    const result = await handleToolCall(name, args as any, progress);
+    const result = await handleToolCall(name, args as any, progress, signal);
     mcpLogger.debug('tool', { event: 'success', tool: name });
     return result;
   } catch (error) {

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createContext, CancellationError, throwIfCancelled } from '../src/handlers/types.js';
+import { handleAdmin } from '../src/handlers/admin.js';
+import { handleMemory } from '../src/handlers/memory.js';
+import { withConcurrency } from '../src/format.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testConfig = {
+  privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  apiUrl: 'http://localhost:9999',
+  configSource: 'test' as const,
+};
+
+function mockApi(routeResponses: Record<string, any>) {
+  const calls: Array<{ method: string; path: string; body?: any }> = [];
+  return {
+    makeRequest: vi.fn(async (method: string, path: string, body?: any) => {
+      calls.push({ method, path, body });
+      const key = `${method} ${path.split('?')[0]}`;
+      if (key in routeResponses) {
+        const resp = routeResponses[key];
+        if (resp instanceof Error) throw resp;
+        return typeof resp === 'function' ? resp(method, path, body) : resp;
+      }
+      return {};
+    }),
+    account: { address: '0xTEST', privateKey: testConfig.privateKey },
+    calls,
+  };
+}
+
+function makeCtx(routes: Record<string, any> = {}, signal?: AbortSignal) {
+  const api = mockApi(routes);
+  return { ctx: createContext(api as any, testConfig, undefined, signal), api };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CancellationError & throwIfCancelled', () => {
+  it('throwIfCancelled is a no-op when signal is not aborted', () => {
+    const ac = new AbortController();
+    expect(() => throwIfCancelled(ac.signal)).not.toThrow();
+  });
+
+  it('throwIfCancelled throws CancellationError when aborted', () => {
+    const ac = new AbortController();
+    ac.abort();
+    expect(() => throwIfCancelled(ac.signal)).toThrow(CancellationError);
+  });
+});
+
+describe('withConcurrency respects AbortSignal', () => {
+  it('stops processing remaining tasks when signal is aborted', async () => {
+    const ac = new AbortController();
+    let executed = 0;
+    const tasks = Array.from({ length: 10 }, (_, i) => async () => {
+      executed++;
+      if (i === 2) ac.abort(); // abort after 3rd task
+      return i;
+    });
+    const results = await withConcurrency(tasks, 1, ac.signal);
+    // With concurrency=1, tasks run sequentially.
+    // Task 2 aborts, so task 3+ should be skipped.
+    expect(executed).toBeLessThanOrEqual(4); // at most task 0,1,2 + possibly 3
+    expect(results.length).toBeLessThan(10);
+  });
+
+  it('completes all tasks when signal is never aborted', async () => {
+    const ac = new AbortController();
+    const tasks = Array.from({ length: 5 }, (_, i) => async () => i);
+    const results = await withConcurrency(tasks, 2, ac.signal);
+    expect(results.length).toBe(5);
+    expect(results.every(r => r.status === 'fulfilled')).toBe(true);
+  });
+});
+
+describe('handler cancellation - delete_namespace', () => {
+  it('returns partial results when cancelled mid-operation', async () => {
+    const ac = new AbortController();
+    let listCallCount = 0;
+    const routes: Record<string, any> = {
+      'GET /v1/memories': () => {
+        listCallCount++;
+        // Return a full page to trigger another loop iteration
+        return {
+          memories: Array.from({ length: 100 }, (_, i) => ({
+            id: `mem-${listCallCount}-${i}`,
+          })),
+        };
+      },
+    };
+    // Mock all possible delete routes — abort after some deletions
+    let deleteCount = 0;
+    for (let page = 1; page <= 3; page++) {
+      for (let i = 0; i < 100; i++) {
+        routes[`DELETE /v1/memories/mem-${page}-${i}`] = () => {
+          deleteCount++;
+          if (deleteCount >= 50) ac.abort(); // abort mid-way through deletes
+          return { deleted: true };
+        };
+      }
+    }
+    const { ctx } = makeCtx(routes, ac.signal);
+    const result = await handleAdmin(ctx, 'memoclaw_delete_namespace', { namespace: 'test-ns' });
+    expect(result).not.toBeNull();
+    expect(result!.content[0].text).toContain('Cancelled');
+    expect(result!.structuredContent?.cancelled).toBe(true);
+    // Should have deleted some but not all
+    expect(result!.structuredContent?.deleted).toBeGreaterThan(0);
+  });
+});
+
+describe('handler cancellation - export fallback', () => {
+  it('returns partial results when cancelled mid-pagination', async () => {
+    const ac = new AbortController();
+    let pageCount = 0;
+    const routes: Record<string, any> = {
+      'GET /v1/export': new Error('404 Not Found'),
+      'GET /v1/memories': () => {
+        pageCount++;
+        if (pageCount === 2) ac.abort();
+        return {
+          memories: Array.from({ length: 100 }, (_, i) => ({
+            id: `mem-${pageCount}-${i}`,
+            content: `content ${i}`,
+          })),
+        };
+      },
+    };
+    const { ctx } = makeCtx(routes, ac.signal);
+    const result = await handleAdmin(ctx, 'memoclaw_export', {});
+    expect(result).not.toBeNull();
+    expect(result!.content[0].text).toContain('cancelled');
+    expect(result!.structuredContent?.cancelled).toBe(true);
+  });
+});
+
+describe('handler cancellation - bulk_delete fallback', () => {
+  it('returns partial results when cancelled', async () => {
+    const ac = new AbortController();
+    let deleteCount = 0;
+    const routes: Record<string, any> = {
+      'POST /v1/memories/bulk-delete': new Error('Server error'),
+    };
+    // Add individual delete routes
+    for (let i = 0; i < 5; i++) {
+      routes[`DELETE /v1/memories/id-${i}`] = () => {
+        deleteCount++;
+        if (deleteCount >= 2) ac.abort();
+        return { deleted: true };
+      };
+    }
+    const { ctx } = makeCtx(routes, ac.signal);
+    const result = await handleMemory(ctx, 'memoclaw_bulk_delete', {
+      ids: ['id-0', 'id-1', 'id-2', 'id-3', 'id-4'],
+    });
+    expect(result).not.toBeNull();
+    // Should have partial results
+    expect(result!.structuredContent?.succeeded).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('signal defaults to non-aborted when not provided', () => {
+  it('createContext provides a usable default signal', () => {
+    const api = mockApi({});
+    const ctx = createContext(api as any, testConfig);
+    expect(ctx.signal).toBeDefined();
+    expect(ctx.signal.aborted).toBe(false);
+  });
+});

--- a/tests/handlers/admin.test.ts
+++ b/tests/handlers/admin.test.ts
@@ -123,7 +123,7 @@ describe('handleAdmin', () => {
       );
       const ctx = createContext(api as any, testConfig);
       const result = await handleAdmin(ctx, 'memoclaw_export', {});
-      expect(result!.content[0].text).toContain('Exported 1 memories');
+      expect(result!.content[0].text).toContain('Exported: 1 memories');
     });
   });
 
@@ -261,5 +261,67 @@ describe('handleAdmin', () => {
   it('returns null for unknown tools', async () => {
     const { ctx } = makeCtx();
     expect(await handleAdmin(ctx, 'memoclaw_store', {})).toBeNull();
+  });
+
+  // ── cancellation ─────────────────────────────────────────────────────────
+  describe('cancellation support', () => {
+    it('stops delete_namespace when signal is pre-aborted', async () => {
+      const ac = new AbortController();
+      ac.abort(); // pre-abort so the loop exits on first iteration
+      const api = mockApi({
+        'GET /v1/memories': { memories: [] },
+        'DELETE /v1/memories/': { deleted: true },
+      });
+      const ctx = createContext(api as any, testConfig, undefined, ac.signal);
+      const result = await handleAdmin(ctx, 'memoclaw_delete_namespace', { namespace: 'test' });
+      expect(result!.content[0].text).toContain('Cancelled');
+      expect((result as any).structuredContent.cancelled).toBe(true);
+    });
+
+    it('stops export pagination when signal is aborted', async () => {
+      const ac = new AbortController();
+      let page = 0;
+      const api = mockApiWithErrors(
+        {
+          'GET /v1/memories': () => {
+            page++;
+            if (page >= 2) ac.abort();
+            // Return full page to force pagination
+            return { memories: Array.from({ length: 100 }, (_, i) => ({ id: `p${page}-${i}`, content: 'x' })) };
+          },
+        },
+        { 'GET /v1/export': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig, undefined, ac.signal);
+      const result = await handleAdmin(ctx, 'memoclaw_export', {});
+      expect(result!.content[0].text).toContain('cancelled');
+      expect((result as any).structuredContent.cancelled).toBe(true);
+    });
+
+    it('stops migrate when signal is aborted mid-file', async () => {
+      const ac = new AbortController();
+      let ingestCount = 0;
+      const api = mockApiWithErrors(
+        {
+          'POST /v1/ingest': () => {
+            ingestCount++;
+            if (ingestCount >= 1) ac.abort();
+            return { memories_created: 1 };
+          },
+        },
+        { 'POST /v1/migrate': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig, undefined, ac.signal);
+      const result = await handleAdmin(ctx, 'memoclaw_migrate', {
+        files: [
+          { filename: 'a.md', content: '# A' },
+          { filename: 'b.md', content: '# B' },
+          { filename: 'c.md', content: '# C' },
+        ],
+      });
+      expect(result!.content[0].text).toContain('cancelled');
+      expect((result as any).structuredContent.cancelled).toBe(true);
+      expect((result as any).structuredContent.files_processed).toBeLessThan(3);
+    });
   });
 });

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -331,4 +331,35 @@ describe('handleMemory', () => {
     const result = await handleMemory(ctx, 'memoclaw_unknown_tool', {});
     expect(result).toBeNull();
   });
+
+  // ── cancellation ─────────────────────────────────────────────────────────
+  describe('cancellation support', () => {
+    it('stops bulk_delete when signal is pre-aborted', async () => {
+      const ac = new AbortController();
+      ac.abort(); // pre-abort
+      const api = mockApiWithErrors(
+        { 'DELETE /v1/memories/': { deleted: true } },
+        { 'POST /v1/memories/bulk-delete': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig, undefined, ac.signal);
+      const ids = Array.from({ length: 20 }, (_, i) => `id-${i}`);
+      const result = await handleMemory(ctx, 'memoclaw_bulk_delete', { ids });
+      expect((result as any).structuredContent.cancelled).toBe(true);
+      expect((result as any).structuredContent.succeeded).toBe(0);
+    });
+
+    it('stops bulk_store when signal is pre-aborted', async () => {
+      const ac = new AbortController();
+      ac.abort(); // pre-abort
+      const api = mockApiWithErrors(
+        { 'POST /v1/store': () => ({ memory: { id: 'm1', content: 'x' } }) },
+        { 'POST /v1/store/batch': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig, undefined, ac.signal);
+      const memories = Array.from({ length: 20 }, (_, i) => ({ content: `memory ${i}` }));
+      const result = await handleMemory(ctx, 'memoclaw_bulk_store', { memories });
+      expect((result as any).structuredContent.cancelled).toBe(true);
+      expect((result as any).structuredContent.succeeded).toBe(0);
+    });
+  });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -945,7 +945,7 @@ describe('Tool Handlers', () => {
     const result = await callToolHandler({
       params: { name: 'memoclaw_export', arguments: {} },
     });
-    expect(result.content[0].text).toContain('Exported 150 memories');
+    expect(result.content[0].text).toContain('Exported: 150 memories');
   });
 
   it('export with jsonl format', async () => {


### PR DESCRIPTION
## Summary

Implements MCP cancellation support per the spec's `notifications/cancelled` mechanism. When a client cancels a long-running request, the server now stops processing and returns partial results.

### Changes

- **`HandlerContext.signal`** — `AbortSignal` from the MCP SDK's `extra.signal` is threaded through all handler contexts
- **`withConcurrency`** — accepts optional `AbortSignal`; workers skip remaining tasks when aborted
- **Pagination loops** — export, delete_namespace, migrate, tags, and namespaces check `signal.aborted` between iterations
- **Partial results** — cancelled operations return what completed with clear messaging (e.g. '⚠️ Bulk delete cancelled: 15 of 50 succeeded') and `cancelled: true` in structured content
- **Utilities** — `throwIfCancelled(signal)` helper and `CancellationError` class

### Affected tools
- `memoclaw_bulk_delete`
- `memoclaw_bulk_store`
- `memoclaw_batch_update`
- `memoclaw_delete_namespace`
- `memoclaw_export`
- `memoclaw_migrate`
- `memoclaw_import`
- `memoclaw_tags` / `memoclaw_namespaces`

### Tests
- 8 dedicated cancellation tests (`tests/cancellation.test.ts`)
- 5 handler-level cancellation tests (admin + memory)
- All 448 tests passing

Fixes #116