### PR TITLE
fix: add missing count filters, remove dead code, fix version fallback

### DIFF
--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -3,7 +3,6 @@ import { join, extname, basename } from 'node:path';
 import { formatMemory, withConcurrency, validateContentLength, validateImportance, userAndAssistantText, assistantText, userText, memoryResourceLink } from '../format.js';
 import { validateIdentifier, validateId } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
-import { throwIfCancelled, CancellationError } from './types.js';
 import type {
   StatusArgs, InitArgs, IngestArgs, ExtractArgs, ConsolidateArgs,
   ExportArgs, MigrateArgs, DeleteNamespaceArgs, TagsArgs, HistoryArgs,

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -445,12 +445,15 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_count': {
-      const { namespace, tags, agent_id, memory_type } = args as CountArgs;
+      const { namespace, tags, agent_id, memory_type, session_id, before, after } = args as CountArgs;
       const params = new URLSearchParams();
       if (namespace) params.set('namespace', namespace);
       if (tags && Array.isArray(tags) && tags.length > 0) params.set('tags', tags.join(','));
       if (agent_id) params.set('agent_id', agent_id);
       if (memory_type) params.set('memory_type', memory_type);
+      if (session_id) params.set('session_id', session_id);
+      if (before) params.set('before', before);
+      if (after) params.set('after', after);
 
       let total: number | string = 'unknown';
       try {
@@ -487,7 +490,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         }
       }
 
-      const filters = [namespace && `namespace=${namespace}`, memory_type && `type=${memory_type}`, agent_id && `agent=${agent_id}`, tags?.length && `tags=${tags.join(',')}`].filter(Boolean);
+      const filters = [namespace && `namespace=${namespace}`, memory_type && `type=${memory_type}`, agent_id && `agent=${agent_id}`, session_id && `session=${session_id}`, tags?.length && `tags=${tags.join(',')}`, after && `after=${after}`, before && `before=${before}`].filter(Boolean);
       const filterStr = filters.length > 0 ? ` (${filters.join(', ')})` : '';
       return {
         content: [userText(`📊 Total memories${filterStr}: ${total}`, 0.5)],

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import type { LogLevel } from './logging.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
-let VERSION = '1.17.0';
+let VERSION = 'unknown';
 try {
   const pkg = JSON.parse(await readFile(join(__dirname, '..', 'package.json'), 'utf-8'));
   VERSION = pkg.version;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -696,6 +696,9 @@ export const TOOLS = [
         tags: { type: 'array', items: { type: 'string' }, description: 'Count only memories with ALL of these tags.' },
         agent_id: { type: 'string', description: 'Count only memories from this agent.' },
         memory_type: { type: 'string', enum: MEMORY_TYPE_ENUM, description: 'Count only memories of this type.' },
+        session_id: { type: 'string', description: 'Count only memories from this session.' },
+        after: { type: 'string', description: 'Count only memories created after this ISO 8601 date, e.g. "2025-01-01T00:00:00Z".' },
+        before: { type: 'string', description: 'Count only memories created before this ISO 8601 date, e.g. "2025-12-31T23:59:59Z".' },
       },
     },
     outputSchema: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,9 @@ export interface CountArgs {
   tags?: string[];
   agent_id?: string;
   memory_type?: string;
+  session_id?: string;
+  before?: string;
+  after?: string;
 }
 
 export interface DeleteNamespaceArgs {

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -323,6 +323,27 @@ describe('handleMemory', () => {
       const result = await handleMemory(ctx, 'memoclaw_count', {});
       expect(result!.content[0].text).toContain('15');
     });
+
+    it('passes session_id, before, and after filters', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories/count': { count: 7 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_count', {
+        namespace: 'ns1',
+        session_id: 'sess-123',
+        after: '2025-01-01T00:00:00Z',
+        before: '2025-12-31T23:59:59Z',
+      });
+      expect(result!.content[0].text).toContain('7');
+      expect(result!.content[0].text).toContain('session=sess-123');
+      expect(result!.content[0].text).toContain('after=2025-01-01T00:00:00Z');
+      expect(result!.content[0].text).toContain('before=2025-12-31T23:59:59Z');
+      // Verify params were passed to API
+      const callUrl = api.makeRequest.mock.calls[0][1];
+      expect(callUrl).toContain('session_id=sess-123');
+      expect(callUrl).toContain('after=2025-01-01T00%3A00%3A00Z');
+      expect(callUrl).toContain('before=2025-12-31T23%3A59%3A59Z');
+    });
   });
 
   // ── unknown tool returns null ────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Bug Fix: Missing filters in `memoclaw_count` (Fixes #120)

`memoclaw_count` was missing `session_id`, `before`, and `after` filter params that all other list/filter operations support. Users couldn't count memories filtered by session or date range.

**Changed:**
- `src/types.ts` — Added `session_id`, `before`, `after` to `CountArgs`
- `src/handlers/memory.ts` — Pass new params in the `memoclaw_count` handler
- `src/tools.ts` — Updated tool schema with new properties
- `tests/handlers/memory.test.ts` — Added test verifying new filters are passed to API

### Cleanup: Remove unused imports (Fixes #121)

Removed unused `throwIfCancelled` and `CancellationError` imports from `src/handlers/admin.ts`. The cancellation logic uses `signal.aborted` checks directly.

### Fix: Hardcoded version fallback (Fixes #122)

Replaced hardcoded `'1.17.0'` fallback in `src/index.ts` with `'unknown'`. The hardcoded value would drift from `package.json` on every release.

## Testing

All 449 tests pass (448 existing + 1 new).