### PR TITLE
fix: add missing validation and fields to memoclaw_update

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -117,6 +117,7 @@ export function errorText(text: string): TextContentItem {
 export const UPDATE_FIELDS = new Set([
   'content', 'importance', 'memory_type', 'namespace',
   'metadata', 'expires_at', 'pinned', 'tags', 'immutable',
+  'session_id', 'agent_id',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -98,6 +98,11 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       }
       if (typeof updateFields.content === 'string') validateContentLength(updateFields.content);
       validateImportance(updateFields.importance);
+      validateIdentifier(updateFields.namespace, 'namespace');
+      validateIdentifier(updateFields.memory_type, 'memory_type');
+      validateIdentifier(updateFields.session_id, 'session_id');
+      validateIdentifier(updateFields.agent_id, 'agent_id');
+      validateTags(updateFields.tags);
       const result = await makeRequest('PATCH', `/v1/memories/${id}`, updateFields);
       const memory = result.memory || result;
       return {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -324,6 +324,8 @@ export const TOOLS = [
         pinned: { type: 'boolean', description: 'Pin or unpin the memory.' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Replace tags array.' },
         immutable: { type: 'boolean', description: 'Set to true to make this memory immutable. WARNING: This is a one-way operation — once set, the memory cannot be updated or deleted.' },
+        session_id: { type: 'string', description: 'Update the session ID associated with this memory.' },
+        agent_id: { type: 'string', description: 'Update the agent ID associated with this memory.' },
       },
       required: ['id'],
     },

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -130,6 +130,34 @@ describe('handleMemory', () => {
       const body = api.makeRequest.mock.calls[0][2];
       expect(body.metadata).toEqual({ key: 'val' });
     });
+
+    it('rejects invalid namespace characters in update', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_update', { id: '1', namespace: 'bad namespace!' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+
+    it('rejects invalid memory_type characters in update', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_update', { id: '1', memory_type: 'type with spaces' }))
+        .rejects.toThrow('memory_type contains invalid characters');
+    });
+
+    it('passes session_id and agent_id to API', async () => {
+      const { ctx, api } = makeCtx({
+        'PATCH /v1/memories/': { memory: { id: '1', content: 'test' } },
+      });
+      await handleMemory(ctx, 'memoclaw_update', { id: '1', session_id: 'sess1', agent_id: 'agent1' });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.session_id).toBe('sess1');
+      expect(body.agent_id).toBe('agent1');
+    });
+
+    it('validates tags in update', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_update', { id: '1', tags: [123 as any] }))
+        .rejects.toThrow('tags[0] must be a non-empty string');
+    });
   });
 
   // ── delete ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Bug Fix: Missing validation in `memoclaw_update` (Fixes #124)

The update handler was missing input validation that all other handlers (`store`, `recall`, `search`, `list`) consistently perform. Additionally, `session_id` and `agent_id` were defined in `UpdateArgs` but silently dropped because they weren't in `UPDATE_FIELDS`.

**Changed:**
- `src/handlers/memory.ts` — Added `validateIdentifier()` for `namespace`, `memory_type`, `session_id`, `agent_id` and `validateTags()` for `tags` in the update handler
- `src/format.ts` — Added `session_id` and `agent_id` to `UPDATE_FIELDS`
- `src/tools.ts` — Added `session_id` and `agent_id` properties to the update tool's inputSchema
- `tests/handlers/memory.test.ts` — Added 4 tests: invalid namespace, invalid memory_type, session_id/agent_id passthrough, invalid tags

## Testing

All 452 tests pass (448 existing + 4 new).