### PR TITLE
fix: add consistent input validation across all handler modules

### DIFF
--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -107,6 +107,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_consolidate': {
       const { namespace, min_similarity, mode, dry_run, agent_id } = args as ConsolidateArgs;
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(agent_id, 'agent_id');
       const body: any = {};
       if (namespace) body.namespace = namespace;
       if (agent_id) body.agent_id = agent_id;
@@ -126,6 +128,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_export': {
       const { namespace, agent_id, format: fmt } = args as ExportArgs;
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(agent_id, 'agent_id');
       const params = new URLSearchParams();
       if (namespace) params.set('namespace', namespace);
       if (agent_id) params.set('agent_id', agent_id);
@@ -349,6 +353,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_tags': {
       const { namespace, agent_id } = args as TagsArgs;
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(agent_id, 'agent_id');
       try {
         const params = new URLSearchParams();
         if (namespace) params.set('namespace', namespace);
@@ -426,6 +432,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_namespaces': {
       const { agent_id } = args as NamespacesArgs;
+      validateIdentifier(agent_id, 'agent_id');
       try {
         const params = new URLSearchParams();
         if (agent_id) params.set('agent_id', agent_id);
@@ -470,6 +477,8 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
 
     case 'memoclaw_core_memories': {
       const { limit, namespace, agent_id } = args as CoreMemoriesArgs;
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(agent_id, 'agent_id');
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (namespace) params.set('namespace', namespace);

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -61,6 +61,11 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_list': {
       const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after, before } = args as ListArgs;
+      validateTags(tags);
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(memory_type, 'memory_type');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (offset !== undefined) params.set('offset', String(offset));
@@ -383,6 +388,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       for (const [i, u] of updates.entries()) {
         if (!u.id) throw new Error(`Update at index ${i} is missing "id"`);
         validateImportance(u.importance, `Update at index ${i} importance`);
+        validateTags(u.tags, `Update at index ${i} tags`);
       }
       try {
         const result = await makeRequest('POST', '/v1/memories/batch-update', { updates });

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -100,6 +100,10 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
 
     case 'memoclaw_suggested': {
       const { limit, namespace, session_id, agent_id, category } = args as SuggestedArgs;
+      validateIdentifier(namespace, 'namespace');
+      validateIdentifier(session_id, 'session_id');
+      validateIdentifier(agent_id, 'agent_id');
+      validateIdentifier(category, 'category');
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (namespace) params.set('namespace', namespace);

--- a/tests/handlers/admin.test.ts
+++ b/tests/handlers/admin.test.ts
@@ -258,6 +258,39 @@ describe('handleAdmin', () => {
     });
   });
 
+  // ── input validation consistency ──────────────────────────────────────────
+  describe('input validation', () => {
+    it('consolidate rejects invalid namespace', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_consolidate', { namespace: 'bad namespace!' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+
+    it('export rejects invalid agent_id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_export', { agent_id: 'bad agent!' }))
+        .rejects.toThrow('agent_id contains invalid characters');
+    });
+
+    it('tags rejects invalid namespace', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_tags', { namespace: '<script>' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+
+    it('namespaces rejects invalid agent_id', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_namespaces', { agent_id: 'has spaces' }))
+        .rejects.toThrow('agent_id contains invalid characters');
+    });
+
+    it('core_memories rejects invalid namespace', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleAdmin(ctx, 'memoclaw_core_memories', { namespace: 'a&b' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+  });
+
   it('returns null for unknown tools', async () => {
     const { ctx } = makeCtx();
     expect(await handleAdmin(ctx, 'memoclaw_store', {})).toBeNull();

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -98,6 +98,18 @@ describe('handleMemory', () => {
       const path = api.makeRequest.mock.calls[0][1];
       expect(path).toContain('before=2025-06-01T00%3A00%3A00Z');
     });
+
+    it('validates namespace identifier', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_list', { namespace: 'bad namespace!' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+
+    it('validates tags array', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_list', { tags: ['valid', ''] }))
+        .rejects.toThrow('tags[1] must be a non-empty string');
+    });
   });
 
   // ── update ───────────────────────────────────────────────────────────────
@@ -301,6 +313,13 @@ describe('handleMemory', () => {
       await expect(handleMemory(ctx, 'memoclaw_batch_update', {
         updates: [{ content: 'no id' }],
       })).rejects.toThrow('missing "id"');
+    });
+
+    it('validates tags in individual updates', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleMemory(ctx, 'memoclaw_batch_update', {
+        updates: [{ id: '1', tags: ['valid', ''] }],
+      })).rejects.toThrow('tags[1] must be a non-empty string');
     });
   });
 

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -139,6 +139,18 @@ describe('handleRecall', () => {
       const result = await handleRecall(ctx, 'memoclaw_suggested', { category: 'personal' });
       expect(result!.content[0].text).toContain('(personal)');
     });
+
+    it('validates namespace identifier', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRecall(ctx, 'memoclaw_suggested', { namespace: 'bad namespace!' }))
+        .rejects.toThrow('namespace contains invalid characters');
+    });
+
+    it('validates category identifier', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRecall(ctx, 'memoclaw_suggested', { category: 'bad cat!' }))
+        .rejects.toThrow('category contains invalid characters');
+    });
   });
 
   describe('memoclaw_check_duplicates', () => {


### PR DESCRIPTION
## Changes

### Bug Fix: Inconsistent input validation (Fixes #126)

Several handlers were missing input validation that other handlers consistently apply. `memoclaw_store`, `memoclaw_recall`, and `memoclaw_search` all validate identifiers (`namespace`, `session_id`, `agent_id`, `memory_type`) and tags, but the following handlers skipped validation entirely:

**Handlers fixed:**
- `memoclaw_list` — added `validateIdentifier()` for namespace/memory_type/session_id/agent_id + `validateTags()`
- `memoclaw_batch_update` — added `validateTags()` for individual update entries
- `memoclaw_suggested` — added `validateIdentifier()` for namespace/session_id/agent_id/category
- `memoclaw_consolidate` — added `validateIdentifier()` for namespace/agent_id
- `memoclaw_export` — added `validateIdentifier()` for namespace/agent_id
- `memoclaw_tags` — added `validateIdentifier()` for namespace/agent_id
- `memoclaw_namespaces` — added `validateIdentifier()` for agent_id
- `memoclaw_core_memories` — added `validateIdentifier()` for namespace/agent_id

**Impact:** Invalid identifiers (special characters, excessively long strings) now get clear client-side validation errors instead of confusing API responses or potential URL parameter issues.

### Files Changed
- `src/handlers/memory.ts` — validation for list + batch_update
- `src/handlers/recall.ts` — validation for suggested
- `src/handlers/admin.ts` — validation for consolidate, export, tags, namespaces, core_memories
- `tests/handlers/memory.test.ts` — 3 new tests
- `tests/handlers/recall.test.ts` — 2 new tests
- `tests/handlers/admin.test.ts` — 5 new tests

## Testing

All 458 tests pass (448 existing + 10 new). Build clean.