### PR TITLE
fix: replace req.emit monkey-patch with standard data listener for body size enforcement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,30 +303,24 @@ async function main() {
 
     /**
      * Enforce body size limit on streaming request bodies (for chunked transfers
-     * or when Content-Length is missing/understated). Wraps the request handler
-     * and destroys the socket if the limit is exceeded mid-stream.
+     * or when Content-Length is missing/understated). Uses a standard 'data'
+     * event listener to track incoming bytes and destroys the request if the
+     * limit is exceeded.
      */
     function enforceBodyLimit(req: import('node:http').IncomingMessage, res: import('node:http').ServerResponse): void {
       let received = 0;
-      const originalEmit = req.emit.bind(req);
-      req.emit = function (event: string, ...args: any[]) {
-        if (event === 'data') {
-          const chunk = args[0] as Buffer;
-          received += chunk.length;
-          if (received > MAX_BODY_SIZE) {
-            // Stop processing — reject with 413
-            req.destroy();
-            if (!res.headersSent) {
-              res.writeHead(413, { 'Content-Type': 'application/json' });
-              res.end(JSON.stringify({
-                error: `Request body too large. Maximum allowed size is ${MAX_BODY_SIZE} bytes.`,
-              }));
-            }
-            return false;
+      req.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+        if (received > MAX_BODY_SIZE) {
+          req.destroy();
+          if (!res.headersSent) {
+            res.writeHead(413, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              error: `Request body too large. Maximum allowed size is ${MAX_BODY_SIZE} bytes.`,
+            }));
           }
         }
-        return originalEmit(event, ...args);
-      } as any;
+      });
     }
 
     /**


### PR DESCRIPTION
## Summary
Replace the fragile `req.emit` monkey-patch in `enforceBodyLimit()` with a standard `req.on('data', ...)` listener.

## Problem
The previous implementation overrode `req.emit` to intercept `data` events for tracking body size. This is:
- **Fragile** — monkey-patching built-in `EventEmitter.emit` can break with Node.js internals
- **Type-unsafe** — required `as any` cast to hide signature mismatch
- **Non-standard** — not how Node.js docs recommend handling streaming data

## Solution
Use a simple `req.on('data', ...)` listener that tracks received bytes and destroys the request if the limit is exceeded. This is:
- **Additive** — doesn't override any built-in methods
- **Standard** — follows Node.js patterns for data event handling
- **Type-safe** — no casts needed

## Testing
All 491 tests pass, including the 45 HTTP transport tests (specifically the `rejects requests with Content-Length exceeding limit` test).

Fixes #137