### PR TITLE
feat: add rate limiting to HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ The server exposes:
 
 Configure your MCP client to connect to `http://localhost:3100/mcp`.
 
+### Rate Limiting
+
+The HTTP transport includes built-in rate limiting to prevent abuse:
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `MEMOCLAW_RATE_LIMIT` | `60` | Max requests per IP per window |
+| `MEMOCLAW_GLOBAL_RATE_LIMIT` | `200` | Max total requests per window |
+| `MEMOCLAW_SESSION_RATE_LIMIT` | `10` | Max new sessions per IP per window |
+| `MEMOCLAW_RATE_LIMIT_WINDOW_MS` | `60000` | Window duration in ms (1 minute) |
+
+Set any limit to `0` to disable it. Rate-limited requests receive a `429 Too Many Requests` response with a `Retry-After` header.
+
 ## Tools
 
 ### Core

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { PROMPTS, createPromptHandler } from './prompts.js';
 import { createCompletionHandler } from './completions.js';
 import { mcpLogger } from './logging.js';
 import type { LogLevel } from './logging.js';
+import { RateLimiter, loadRateLimitConfig, getClientIp } from './rate-limiter.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -254,6 +255,10 @@ async function main() {
 
     const httpToken = getHttpToken();
 
+    // Rate limiting
+    const rateLimitConfig = loadRateLimitConfig();
+    const rateLimiter = new RateLimiter();
+
     /**
      * Allowed origins for HTTP transport.
      * Validates Origin header to prevent DNS rebinding attacks.
@@ -397,6 +402,33 @@ async function main() {
 
       // MCP endpoint
       if (url.pathname === '/mcp') {
+        // Rate limiting (per-IP and global)
+        const clientIp = getClientIp(req);
+
+        // Check global rate limit
+        const globalCheck = rateLimiter.check('__global__', rateLimitConfig.globalLimit, rateLimitConfig.windowMs);
+        if (!globalCheck.allowed) {
+          const retryAfter = Math.ceil(globalCheck.retryAfterMs / 1000);
+          res.writeHead(429, {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfter),
+          });
+          res.end(JSON.stringify({ error: 'Too many requests (global limit). Try again later.' }));
+          return;
+        }
+
+        // Check per-IP rate limit
+        const ipCheck = rateLimiter.check(`ip:${clientIp}`, rateLimitConfig.perIpLimit, rateLimitConfig.windowMs);
+        if (!ipCheck.allowed) {
+          const retryAfter = Math.ceil(ipCheck.retryAfterMs / 1000);
+          res.writeHead(429, {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfter),
+          });
+          res.end(JSON.stringify({ error: 'Too many requests. Try again later.' }));
+          return;
+        }
+
         // Enforce request body size limit for POST requests (prevents DoS via large payloads)
         if (req.method === 'POST') {
           if (checkBodySize(req, res)) return;
@@ -433,6 +465,18 @@ async function main() {
           // GET without valid session → error (SSE needs an existing session)
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Invalid or missing session ID. Send a POST first to initialize.' }));
+          return;
+        }
+
+        // Check session creation rate limit (per-IP)
+        const sessionCheck = rateLimiter.check(`session:${clientIp}`, rateLimitConfig.sessionLimit, rateLimitConfig.windowMs);
+        if (!sessionCheck.allowed) {
+          const retryAfter = Math.ceil(sessionCheck.retryAfterMs / 1000);
+          res.writeHead(429, {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfter),
+          });
+          res.end(JSON.stringify({ error: 'Too many new sessions. Try again later.' }));
           return;
         }
 

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,99 @@
+/**
+ * Simple in-memory sliding window rate limiter.
+ * No external dependencies. Tracks request counts per key within configurable time windows.
+ */
+export class RateLimiter {
+  private windows = new Map<string, { count: number; resetAt: number }>();
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    // Periodically clean up expired entries to prevent memory leaks
+    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
+    this.cleanupTimer.unref(); // Don't prevent process exit
+  }
+
+  /**
+   * Check if a request is allowed under the rate limit.
+   * @param key - Identifier (e.g. IP address, "global")
+   * @param limit - Maximum requests allowed in the window
+   * @param windowMs - Window duration in milliseconds
+   * @returns Object with `allowed` boolean and `retryAfterMs` (ms until window resets, 0 if allowed)
+   */
+  check(key: string, limit: number, windowMs: number): { allowed: boolean; retryAfterMs: number } {
+    if (limit <= 0) return { allowed: true, retryAfterMs: 0 }; // Disabled
+
+    const now = Date.now();
+    const entry = this.windows.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      // Window expired or first request — start new window
+      this.windows.set(key, { count: 1, resetAt: now + windowMs });
+      return { allowed: true, retryAfterMs: 0 };
+    }
+
+    if (entry.count >= limit) {
+      // Rate limited
+      return { allowed: false, retryAfterMs: entry.resetAt - now };
+    }
+
+    entry.count++;
+    return { allowed: true, retryAfterMs: 0 };
+  }
+
+  /** Remove expired entries */
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.windows) {
+      if (now >= entry.resetAt) {
+        this.windows.delete(key);
+      }
+    }
+  }
+
+  /** Stop the cleanup timer (for graceful shutdown) */
+  dispose(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+}
+
+export interface RateLimitConfig {
+  /** Per-IP requests per window (default 60, 0 to disable) */
+  perIpLimit: number;
+  /** Global requests per window (default 200, 0 to disable) */
+  globalLimit: number;
+  /** Session creation per IP per window (default 10, 0 to disable) */
+  sessionLimit: number;
+  /** Window size in ms (default 60000 = 1 minute) */
+  windowMs: number;
+}
+
+export function loadRateLimitConfig(): RateLimitConfig {
+  const windowMs = parseInt(process.env.MEMOCLAW_RATE_LIMIT_WINDOW_MS || '', 10) || 60_000;
+  const perIpLimit = parseEnvInt('MEMOCLAW_RATE_LIMIT', 60);
+  const globalLimit = parseEnvInt('MEMOCLAW_GLOBAL_RATE_LIMIT', 200);
+  const sessionLimit = parseEnvInt('MEMOCLAW_SESSION_RATE_LIMIT', 10);
+
+  return { perIpLimit, globalLimit, sessionLimit, windowMs };
+}
+
+function parseEnvInt(envVar: string, defaultVal: number): number {
+  const raw = process.env[envVar];
+  if (raw === undefined || raw === '') return defaultVal;
+  const parsed = parseInt(raw, 10);
+  return isNaN(parsed) ? defaultVal : parsed;
+}
+
+/**
+ * Extract client IP from request, respecting X-Forwarded-For if present.
+ */
+export function getClientIp(req: import('node:http').IncomingMessage): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return req.socket.remoteAddress || 'unknown';
+}

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the RateLimiter class and HTTP rate limiting integration.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RateLimiter } from '../src/rate-limiter.js';
+import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter();
+  });
+
+  afterEach(() => {
+    limiter.dispose();
+  });
+
+  it('allows requests within the limit', () => {
+    for (let i = 0; i < 5; i++) {
+      const result = limiter.check('test-key', 5, 60_000);
+      expect(result.allowed).toBe(true);
+      expect(result.retryAfterMs).toBe(0);
+    }
+  });
+
+  it('rejects requests exceeding the limit', () => {
+    for (let i = 0; i < 3; i++) {
+      limiter.check('test-key', 3, 60_000);
+    }
+    const result = limiter.check('test-key', 3, 60_000);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('allows requests after window expires', () => {
+    vi.useFakeTimers();
+    try {
+      // Fill up the limit
+      for (let i = 0; i < 3; i++) {
+        limiter.check('test-key', 3, 1000);
+      }
+      expect(limiter.check('test-key', 3, 1000).allowed).toBe(false);
+
+      // Advance past window
+      vi.advanceTimersByTime(1001);
+      expect(limiter.check('test-key', 3, 1000).allowed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tracks different keys independently', () => {
+    for (let i = 0; i < 3; i++) {
+      limiter.check('key-a', 3, 60_000);
+    }
+    expect(limiter.check('key-a', 3, 60_000).allowed).toBe(false);
+    expect(limiter.check('key-b', 3, 60_000).allowed).toBe(true);
+  });
+
+  it('returns allowed when limit is 0 (disabled)', () => {
+    const result = limiter.check('any-key', 0, 60_000);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('returns retryAfterMs close to remaining window time', () => {
+    vi.useFakeTimers();
+    try {
+      for (let i = 0; i < 2; i++) {
+        limiter.check('test-key', 2, 10_000);
+      }
+      vi.advanceTimersByTime(3000);
+      const result = limiter.check('test-key', 2, 10_000);
+      expect(result.allowed).toBe(false);
+      // Should be ~7000ms remaining
+      expect(result.retryAfterMs).toBeLessThanOrEqual(7000);
+      expect(result.retryAfterMs).toBeGreaterThan(6000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// --- HTTP integration tests ---
+
+function buildRateLimitedHandler(opts: {
+  perIpLimit?: number;
+  globalLimit?: number;
+  sessionLimit?: number;
+  windowMs?: number;
+} = {}) {
+  const config = {
+    perIpLimit: opts.perIpLimit ?? 5,
+    globalLimit: opts.globalLimit ?? 20,
+    sessionLimit: opts.sessionLimit ?? 2,
+    windowMs: opts.windowMs ?? 60_000,
+  };
+  const limiter = new RateLimiter();
+  const sessions = new Map<string, boolean>();
+
+  function getClientIp(req: IncomingMessage): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string') {
+      const first = forwarded.split(',')[0]?.trim();
+      if (first) return first;
+    }
+    return req.socket.remoteAddress || 'unknown';
+  }
+
+  return {
+    limiter,
+    handler: (req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || '/', 'http://localhost');
+
+      if (url.pathname === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (url.pathname === '/mcp') {
+        const clientIp = getClientIp(req);
+
+        // Global rate limit
+        const globalCheck = limiter.check('__global__', config.globalLimit, config.windowMs);
+        if (!globalCheck.allowed) {
+          const retryAfter = Math.ceil(globalCheck.retryAfterMs / 1000);
+          res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
+          res.end(JSON.stringify({ error: 'Too many requests (global limit). Try again later.' }));
+          return;
+        }
+
+        // Per-IP rate limit
+        const ipCheck = limiter.check(`ip:${clientIp}`, config.perIpLimit, config.windowMs);
+        if (!ipCheck.allowed) {
+          const retryAfter = Math.ceil(ipCheck.retryAfterMs / 1000);
+          res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
+          res.end(JSON.stringify({ error: 'Too many requests. Try again later.' }));
+          return;
+        }
+
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+        // Session creation (POST without session ID)
+        if (req.method === 'POST' && !sessionId) {
+          const sessionCheck = limiter.check(`session:${clientIp}`, config.sessionLimit, config.windowMs);
+          if (!sessionCheck.allowed) {
+            const retryAfter = Math.ceil(sessionCheck.retryAfterMs / 1000);
+            res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
+            res.end(JSON.stringify({ error: 'Too many new sessions. Try again later.' }));
+            return;
+          }
+          const newId = `session-${sessions.size + 1}`;
+          sessions.set(newId, true);
+          res.writeHead(200, { 'Content-Type': 'application/json', 'Mcp-Session-Id': newId });
+          res.end(JSON.stringify({ jsonrpc: '2.0', result: { ok: true }, id: 1 }));
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', result: { ok: true }, id: 1 }));
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    },
+  };
+}
+
+function startServer(handler: (req: IncomingMessage, res: ServerResponse) => void): Promise<{ server: HttpServer; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+function stopServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('HTTP Rate Limiting Integration', () => {
+  let server: HttpServer;
+  let port: number;
+  let ctx: ReturnType<typeof buildRateLimitedHandler>;
+
+  beforeEach(async () => {
+    ctx = buildRateLimitedHandler({ perIpLimit: 3, globalLimit: 10, sessionLimit: 2 });
+    const result = await startServer(ctx.handler);
+    server = result.server;
+    port = result.port;
+  });
+
+  afterEach(async () => {
+    ctx.limiter.dispose();
+    await stopServer(server);
+  });
+
+  it('allows requests within per-IP limit', async () => {
+    for (let i = 0; i < 3; i++) {
+      const res = await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('returns 429 when per-IP limit exceeded', async () => {
+    // Use up the limit
+    for (let i = 0; i < 3; i++) {
+      await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+      });
+    }
+
+    // Next request should be rate limited
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toContain('Too many requests');
+    expect(res.headers.get('retry-after')).toBeTruthy();
+  });
+
+  it('does not rate limit /health endpoint', async () => {
+    // Exhaust per-IP limit on /mcp
+    for (let i = 0; i < 3; i++) {
+      await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+      });
+    }
+
+    // Health check should still work
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 429 when session creation limit exceeded', async () => {
+    // Create sessions up to the limit
+    for (let i = 0; i < 2; i++) {
+      const res = await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // Third session creation should be rate limited
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toContain('Too many new sessions');
+  });
+
+  it('returns 429 when global limit exceeded', async () => {
+    // Use a handler with a very low global limit
+    ctx.limiter.dispose();
+    await stopServer(server);
+
+    ctx = buildRateLimitedHandler({ perIpLimit: 100, globalLimit: 3, sessionLimit: 100 });
+    const result = await startServer(ctx.handler);
+    server = result.server;
+    port = result.port;
+
+    for (let i = 0; i < 3; i++) {
+      await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+      });
+    }
+
+    const res = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Mcp-Session-Id': 'existing' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toContain('global limit');
+  });
+
+  it('respects X-Forwarded-For for IP identification', async () => {
+    // Exhaust limit for IP 1.2.3.4
+    for (let i = 0; i < 3; i++) {
+      await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Forwarded-For': '1.2.3.4',
+          'Mcp-Session-Id': 'existing',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+      });
+    }
+
+    // 1.2.3.4 should be rate limited
+    const blocked = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': '1.2.3.4',
+        'Mcp-Session-Id': 'existing',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+    });
+    expect(blocked.status).toBe(429);
+
+    // Different IP should still be allowed
+    const allowed = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': '5.6.7.8',
+        'Mcp-Session-Id': 'existing',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'test', id: 1 }),
+    });
+    expect(allowed.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
Add in-memory rate limiting to the HTTP transport to prevent abuse and resource exhaustion.

## Problem
The HTTP transport has no rate limiting. A client with a valid token (or on an unauthenticated server) can flood the server with requests, causing:
- Excessive API calls to the MemoClaw backend (burning free tier credits or racking up x402 charges)
- Memory exhaustion from unbounded session creation
- CPU saturation from concurrent tool executions

## Solution
Add a `RateLimiter` class with sliding window counters:

- **Per-IP rate limiting** — 60 requests/minute per IP (configurable via `MEMOCLAW_RATE_LIMIT`)
- **Global rate limiting** — 200 requests/minute total (configurable via `MEMOCLAW_GLOBAL_RATE_LIMIT`)
- **Session creation limit** — 10 new sessions/minute per IP (configurable via `MEMOCLAW_SESSION_RATE_LIMIT`)
- **Window size** — 60 seconds (configurable via `MEMOCLAW_RATE_LIMIT_WINDOW_MS`)

Set any limit to `0` to disable. Returns `429 Too Many Requests` with a `Retry-After` header.

### Implementation details
- Zero external dependencies — pure in-memory sliding window
- Automatic cleanup of expired entries (60s sweep interval, unref'd to not block exit)
- Respects `X-Forwarded-For` for IP extraction behind reverse proxies
- Health endpoint (`/health`) is exempt from rate limiting
- Fully disposable (cleanup timer can be stopped)

## Files changed
- `src/rate-limiter.ts` — New `RateLimiter` class + config loading + IP extraction
- `src/index.ts` — Integrate rate limiting into HTTP request handler
- `tests/rate-limiter.test.ts` — 12 new tests (unit + HTTP integration)
- `README.md` — Document rate limiting configuration

## Testing
All 503 tests pass (12 new + 491 existing).

Fixes #138