### PR TITLE
fix: resolve Prettier formatting violations and clean up unused imports/variables

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -96,7 +96,7 @@ export function validateContentLength(content: string, label = 'content'): void 
 // Content annotation helpers (MCP 2025-06-18)
 // ---------------------------------------------------------------------------
 
-import type { ContentAnnotations, TextContentItem, ResourceLinkContentItem } from './handlers/types.js';
+import type { TextContentItem, ResourceLinkContentItem } from './handlers/types.js';
 
 /**
  * Build a text content item intended for both user and assistant display.

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -3,18 +3,14 @@ import { join, extname, basename } from 'node:path';
 import {
   formatMemory,
   withConcurrency,
-  validateContentLength,
-  validateImportance,
   userAndAssistantText,
   assistantText,
   userText,
   memoryResourceLink,
 } from '../format.js';
-import { validateIdentifier, validateId, validateISODate } from '../validate.js';
+import { validateIdentifier, validateId } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
-  StatusArgs,
-  InitArgs,
   IngestArgs,
   ExtractArgs,
   ConsolidateArgs,
@@ -25,7 +21,6 @@ import type {
   HistoryArgs,
   NamespacesArgs,
   CoreMemoriesArgs,
-  StatsArgs,
 } from '../types.js';
 
 export async function handleAdmin(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
@@ -174,14 +169,12 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         const allMemories: any[] = [];
         let offset = 0;
         const pageSize = 100;
-        let exportPage = 0;
         let exportCancelled = false;
         while (true) {
           if (signal.aborted) {
             exportCancelled = true;
             break;
           }
-          exportPage++;
           const fallbackParams = new URLSearchParams();
           fallbackParams.set('limit', String(pageSize));
           fallbackParams.set('offset', String(offset));

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,7 +483,11 @@ async function main() {
         }
 
         // Check session creation rate limit (per-IP)
-        const sessionCheck = rateLimiter.check(`session:${clientIp}`, rateLimitConfig.sessionLimit, rateLimitConfig.windowMs);
+        const sessionCheck = rateLimiter.check(
+          `session:${clientIp}`,
+          rateLimitConfig.sessionLimit,
+          rateLimitConfig.windowMs,
+        );
         if (!sessionCheck.allowed) {
           const retryAfter = Math.ceil(sessionCheck.retryAfterMs / 1000);
           res.writeHead(429, {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -14,7 +14,6 @@
 
 import type { ApiClient } from './api.js';
 import type { Config } from './config.js';
-import { formatMemory } from './format.js';
 
 /** Static resource list returned by resources/list */
 export const RESOURCES = [

--- a/tests/annotations.test.ts
+++ b/tests/annotations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { handleMemory } from '../src/handlers/memory.js';
 import { handleRecall } from '../src/handlers/recall.js';
 import { handleAdmin } from '../src/handlers/admin.js';

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { handleMemory } from '../../src/handlers/memory.js';
 import { createContext } from '../../src/handlers/types.js';
 import { mockApi, mockApiWithErrors, testConfig } from './helpers.js';

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -11,7 +11,7 @@
  * - Bearer token auth when MEMOCLAW_HTTP_TOKEN is set
  * - 404 for unknown paths
  */
-import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for MCP progress notifications in long-running handlers.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createHandler } from '../src/handlers/index.js';
 import type { ProgressCallback } from '../src/handlers/types.js';
 

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -83,12 +83,14 @@ describe('RateLimiter', () => {
 
 // --- HTTP integration tests ---
 
-function buildRateLimitedHandler(opts: {
-  perIpLimit?: number;
-  globalLimit?: number;
-  sessionLimit?: number;
-  windowMs?: number;
-} = {}) {
+function buildRateLimitedHandler(
+  opts: {
+    perIpLimit?: number;
+    globalLimit?: number;
+    sessionLimit?: number;
+    windowMs?: number;
+  } = {},
+) {
   const config = {
     perIpLimit: opts.perIpLimit ?? 5,
     globalLimit: opts.globalLimit ?? 20,
@@ -168,7 +170,9 @@ function buildRateLimitedHandler(opts: {
   };
 }
 
-function startServer(handler: (req: IncomingMessage, res: ServerResponse) => void): Promise<{ server: HttpServer; port: number }> {
+function startServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ server: HttpServer; port: number }> {
   return new Promise((resolve) => {
     const server = createServer(handler);
     server.listen(0, () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1223,9 +1223,7 @@ describe('Tool Handlers', () => {
   });
 
   it('graph traverses single level', async () => {
-    let callNum = 0;
     globalThis.fetch = vi.fn().mockImplementation((url: string) => {
-      callNum++;
       if (url.includes('/relations')) {
         return Promise.resolve({
           ok: true,
@@ -1824,7 +1822,7 @@ describe('memoclaw_batch_update', () => {
 
   it('falls back to individual PATCH on 404', async () => {
     let callCount = 0;
-    globalThis.fetch = vi.fn().mockImplementation(async (url: string, opts: any) => {
+    globalThis.fetch = vi.fn().mockImplementation(async (_url: string, _opts: any) => {
       callCount++;
       if (callCount === 1) {
         // First call is batch endpoint - return 404


### PR DESCRIPTION
## Summary

Fixes CI format check failures and cleans up all unused import/variable lint warnings.

### Changes

**Formatting (Fixes #142):**
- Fix Prettier violations in `src/index.ts` and `tests/rate-limiter.test.ts`
- Fix formatting after removing import in `src/resources.ts`

**Unused imports/variables (Fixes #143):**
- Remove unused `ContentAnnotations` import from `src/format.ts`
- Remove 6 unused imports from `src/handlers/admin.ts` (`validateContentLength`, `validateImportance`, `validateISODate`, `StatusArgs`, `InitArgs`, `StatsArgs`)
- Remove unused `formatMemory` import from `src/resources.ts`
- Remove unused `exportPage` variable in admin.ts export fallback path
- Clean up unused vitest imports across 4 test files
- Remove unused `callNum` variable in graph traversal test
- Prefix unused mock params with `_` convention

### Verification
- ✅ `npm run build` — clean
- ✅ `npm run format:check` — all files pass
- ✅ `npm run lint` — 0 errors (254 warnings, all `no-explicit-any`)
- ✅ `npm test` — 503/503 tests pass