### PR TITLE
fix: dispose rate limiter on shutdown and validate min_similarity

### DIFF
--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -8,7 +8,7 @@ import {
   userText,
   memoryResourceLink,
 } from '../format.js';
-import { validateIdentifier, validateId, validatePaginationParam } from '../validate.js';
+import { validateIdentifier, validateId, validatePaginationParam, validateSimilarity } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   IngestArgs,
@@ -127,6 +127,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
       const { namespace, min_similarity, mode, dry_run, agent_id } = args as ConsolidateArgs;
       validateIdentifier(namespace, 'namespace');
       validateIdentifier(agent_id, 'agent_id');
+      validateSimilarity(min_similarity);
       const body: any = {};
       if (namespace) body.namespace = namespace;
       if (agent_id) body.agent_id = agent_id;

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -5,6 +5,7 @@ import {
   validateQuery,
   validateISODate,
   validatePaginationParam,
+  validateSimilarity,
 } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs, CheckDuplicatesArgs } from '../types.js';
@@ -29,6 +30,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       } = args as RecallArgs;
       validateQuery(query);
       validatePaginationParam(limit, 'limit');
+      validateSimilarity(min_similarity);
       validateTags(tags);
       validateIdentifier(namespace, 'namespace');
       validateIdentifier(memory_type, 'memory_type');
@@ -176,6 +178,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (!content || (typeof content === 'string' && content.trim() === '')) {
         throw new Error('content is required and cannot be empty');
       }
+      validateSimilarity(min_similarity);
       validateIdentifier(namespace, 'namespace');
       const threshold = min_similarity ?? 0.7;
       const maxResults = limit ?? 5;

--- a/src/index.ts
+++ b/src/index.ts
@@ -607,6 +607,7 @@ async function main() {
     _httpServer = httpServer;
     _cleanupHttp = () => {
       clearInterval(sweepInterval);
+      rateLimiter.dispose();
       for (const [, transport] of sessions) {
         try {
           transport.close?.();

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -113,6 +113,22 @@ export function validatePaginationParam(value: unknown, label: string, max?: num
 }
 
 /**
+ * Validate a similarity threshold parameter.
+ * Must be a number between 0 and 1 (inclusive).
+ * Returns undefined if value is falsy (optional params), throws on invalid.
+ */
+export function validateSimilarity(value: unknown, label = 'min_similarity'): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`${label} must be a number between 0.0 and 1.0`);
+  }
+  if (value < 0 || value > 1) {
+    throw new Error(`${label} must be between 0.0 and 1.0 (got ${value})`);
+  }
+  return value;
+}
+
+/**
  * Validate an ISO 8601 date string parameter (expires_at, after, before).
  * Returns undefined if value is falsy (optional params), throws on invalid.
  * Accepts any string that `new Date()` can parse to a valid date.

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -169,3 +169,33 @@ describe('validateISODate', () => {
     expect(() => validateISODate('yesterday', 'before')).toThrow('not a valid date');
   });
 });
+
+// ── validateSimilarity ──────────────────────────────────────────────────────
+
+import { validateSimilarity } from '../src/validate.js';
+
+describe('validateSimilarity', () => {
+  it('returns undefined for undefined/null', () => {
+    expect(validateSimilarity(undefined)).toBeUndefined();
+    expect(validateSimilarity(null)).toBeUndefined();
+  });
+
+  it('accepts valid similarity values', () => {
+    expect(validateSimilarity(0)).toBe(0);
+    expect(validateSimilarity(0.5)).toBe(0.5);
+    expect(validateSimilarity(1)).toBe(1);
+    expect(validateSimilarity(0.85)).toBe(0.85);
+  });
+
+  it('rejects non-number values', () => {
+    expect(() => validateSimilarity('0.5')).toThrow('must be a number');
+    expect(() => validateSimilarity(true)).toThrow('must be a number');
+    expect(() => validateSimilarity(NaN)).toThrow('must be a number');
+  });
+
+  it('rejects out-of-range values', () => {
+    expect(() => validateSimilarity(-0.1)).toThrow('must be between 0.0 and 1.0');
+    expect(() => validateSimilarity(1.1)).toThrow('must be between 0.0 and 1.0');
+    expect(() => validateSimilarity(5)).toThrow('must be between 0.0 and 1.0');
+  });
+});


### PR DESCRIPTION
## Changes

### 1. Rate limiter disposal on shutdown
The `RateLimiter` cleanup interval was not being disposed during graceful HTTP shutdown. Added `rateLimiter.dispose()` to the `_cleanupHttp` callback.

### 2. `min_similarity` validation
Added `validateSimilarity()` helper that ensures the value is a number between 0.0 and 1.0. Applied in:
- `memoclaw_recall`
- `memoclaw_check_duplicates`  
- `memoclaw_consolidate`

### Tests
- Added `validateSimilarity` test suite (undefined/null, valid values, non-numbers, out-of-range)
- All 515 tests pass

Fixes #150