### PR TITLE
fix: tighten classifyError to avoid false-matching non-HTTP numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
 });
 
 /** Error codes for structured error responses (MCP 2025-06-18). */
-type ErrorCode =
+export type ErrorCode =
   | 'VALIDATION_ERROR'
   | 'API_ERROR'
   | 'TIMEOUT'
@@ -211,11 +211,21 @@ type ErrorCode =
  * Classify an error into a structured error code.
  * Inspects the error message and known error types to determine the category.
  */
-function classifyError(error: unknown): ErrorCode {
+export function classifyError(error: unknown): ErrorCode {
   if (!error) return 'UNKNOWN';
 
   const name = error instanceof Error ? error.name : '';
   const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+
+  // Timeout (checked before cancellation so ECONNABORTED doesn't match "aborted")
+  if (
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('etimedout') ||
+    msg.includes('econnaborted')
+  ) {
+    return 'TIMEOUT';
+  }
 
   // Cancellation (from MCP notifications/cancelled)
   if (name === 'CancellationError' || msg.includes('cancelled') || msg.includes('aborted')) {
@@ -235,28 +245,20 @@ function classifyError(error: unknown): ErrorCode {
     return 'VALIDATION_ERROR';
   }
 
-  // Rate limiting
-  if (msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')) {
+  // Rate limiting — match "HTTP 429" pattern or descriptive phrases, not bare "429"
+  if (/\bhttp\s+429\b/.test(msg) || msg.includes('rate limit') || msg.includes('too many requests')) {
     return 'RATE_LIMITED';
   }
 
-  // Payment required (x402)
-  if (msg.includes('402') || msg.includes('payment required') || msg.includes('x402')) {
+  // Payment required (x402) — match "HTTP 402" pattern or descriptive phrases, not bare "402"
+  if (/\bhttp\s+402\b/.test(msg) || msg.includes('payment required') || msg.includes('x402')) {
     return 'PAYMENT_REQUIRED';
   }
 
-  // Timeout
-  if (
-    msg.includes('timeout') ||
-    msg.includes('timed out') ||
-    msg.includes('etimedout') ||
-    msg.includes('econnaborted')
-  ) {
-    return 'TIMEOUT';
-  }
-
-  // HTTP/API errors
-  if (msg.includes('http') || msg.includes('status') || /\b[45]\d{2}\b/.test(msg)) {
+  // HTTP/API errors — require "http" or "status" keywords; the standalone
+  // /\b[45]\d{2}\b/ regex was removed because it false-matches non-HTTP numbers
+  // like "port 4500" or "limit of 500" (see issue #153)
+  if (msg.includes('http') || msg.includes('status')) {
     return 'API_ERROR';
   }
 

--- a/tests/classify-error.test.ts
+++ b/tests/classify-error.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { classifyError } from '../src/index.js';
+
+describe('classifyError', () => {
+  it('returns UNKNOWN for falsy input', () => {
+    expect(classifyError(null)).toBe('UNKNOWN');
+    expect(classifyError(undefined)).toBe('UNKNOWN');
+    expect(classifyError('')).toBe('UNKNOWN');
+    expect(classifyError(0)).toBe('UNKNOWN');
+  });
+
+  // --- Timeout (must be checked before cancellation) ---
+  it('classifies timeout errors', () => {
+    expect(classifyError(new Error('Request timed out after 30000ms'))).toBe('TIMEOUT');
+    expect(classifyError(new Error('Connection timeout'))).toBe('TIMEOUT');
+    expect(classifyError(new Error('ETIMEDOUT'))).toBe('TIMEOUT');
+    expect(classifyError(new Error('ECONNABORTED'))).toBe('TIMEOUT');
+  });
+
+  it('classifies ECONNABORTED as TIMEOUT not CANCELLED', () => {
+    // ECONNABORTED contains "aborted" but should be TIMEOUT
+    expect(classifyError(new Error('ECONNABORTED'))).toBe('TIMEOUT');
+  });
+
+  // --- Cancellation ---
+  it('classifies CancellationError by name', () => {
+    const err = new Error('something');
+    err.name = 'CancellationError';
+    expect(classifyError(err)).toBe('CANCELLED');
+  });
+
+  it('classifies "cancelled" in message', () => {
+    expect(classifyError(new Error('Request cancelled by client'))).toBe('CANCELLED');
+  });
+
+  it('classifies "aborted" in message', () => {
+    expect(classifyError(new Error('The operation was aborted'))).toBe('CANCELLED');
+  });
+
+  // --- Validation ---
+  it('classifies validation errors', () => {
+    expect(classifyError(new Error('id is required'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('importance must be a number'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('content cannot be empty'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('namespace contains invalid characters'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('content exceeds 8192 character limit'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('foo is not a valid date'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('no valid update fields'))).toBe('VALIDATION_ERROR');
+  });
+
+  // --- Rate limiting ---
+  it('classifies HTTP 429 as RATE_LIMITED', () => {
+    expect(classifyError(new Error('HTTP 429: Too Many Requests'))).toBe('RATE_LIMITED');
+    expect(classifyError(new Error('http 429'))).toBe('RATE_LIMITED');
+  });
+
+  it('classifies rate limit phrases', () => {
+    expect(classifyError(new Error('rate limit exceeded'))).toBe('RATE_LIMITED');
+    expect(classifyError(new Error('too many requests'))).toBe('RATE_LIMITED');
+  });
+
+  it('does NOT false-match bare "429" without HTTP prefix', () => {
+    expect(classifyError(new Error('connected to port 429'))).not.toBe('RATE_LIMITED');
+    expect(classifyError(new Error('item 429 not found'))).not.toBe('RATE_LIMITED');
+  });
+
+  // --- Payment required ---
+  it('classifies HTTP 402 as PAYMENT_REQUIRED', () => {
+    expect(classifyError(new Error('HTTP 402: Payment Required'))).toBe('PAYMENT_REQUIRED');
+    expect(classifyError(new Error('http 402'))).toBe('PAYMENT_REQUIRED');
+  });
+
+  it('classifies payment phrases', () => {
+    expect(classifyError(new Error('payment required'))).toBe('PAYMENT_REQUIRED');
+    expect(classifyError(new Error('x402 payment needed'))).toBe('PAYMENT_REQUIRED');
+  });
+
+  it('does NOT false-match bare "402" without HTTP prefix', () => {
+    expect(classifyError(new Error('room 402 is unavailable'))).not.toBe('PAYMENT_REQUIRED');
+  });
+
+  // --- API errors ---
+  it('classifies HTTP errors as API_ERROR', () => {
+    expect(classifyError(new Error('HTTP 500: Internal Server Error'))).toBe('API_ERROR');
+    expect(classifyError(new Error('HTTP 503: Service Unavailable'))).toBe('API_ERROR');
+    expect(classifyError(new Error('bad status code'))).toBe('API_ERROR');
+  });
+
+  it('does NOT false-match non-HTTP numbers (issue #153)', () => {
+    expect(classifyError(new Error('port 4500 unavailable'))).toBe('UNKNOWN');
+    expect(classifyError(new Error('limit of 500 exceeded'))).toBe('UNKNOWN');
+    expect(classifyError(new Error('error code 404'))).toBe('UNKNOWN');
+    expect(classifyError(new Error('allocated 512 bytes'))).toBe('UNKNOWN');
+  });
+
+  // --- UNKNOWN fallback ---
+  it('returns UNKNOWN for unrecognized errors', () => {
+    expect(classifyError(new Error('something went wrong'))).toBe('UNKNOWN');
+    expect(classifyError('a plain string error')).toBe('UNKNOWN');
+    expect(classifyError(42)).toBe('UNKNOWN');
+  });
+
+  // --- String input ---
+  it('handles string input (non-Error)', () => {
+    expect(classifyError('HTTP 500: oops')).toBe('API_ERROR');
+    expect(classifyError('request cancelled')).toBe('CANCELLED');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #153 — `classifyError()` regex `/\b[45]\d{2}\b/` could false-match non-HTTP numbers like `port 4500` or `limit of 500`, incorrectly classifying them as `API_ERROR`.

## Changes

- **`src/index.ts`**:
  - Removed standalone `/\b[45]\d{2}\b/` regex from API_ERROR detection — now requires `http` or `status` keywords in the message
  - Replaced bare `'429'`/`'402'` `includes()` checks with `/\bhttp\s+NNN\b/` patterns so messages like `room 402` or `item 429` aren't misclassified
  - Moved timeout check before cancellation so `ECONNABORTED` is correctly classified as `TIMEOUT` (it contains "aborted" which previously matched `CANCELLED`)
  - Exported `classifyError` and `ErrorCode` for direct unit testing

- **`tests/classify-error.test.ts`** (new):
  - Comprehensive test suite covering all error categories
  - Tests for false-match prevention (issue #153 cases)
  - Tests for ECONNABORTED → TIMEOUT priority fix

## Impact

Low. Error codes are informational hints. The only behavioral change is that previously-misclassified errors now get the correct code.

All 541 tests pass.