### PR TITLE
fix: tighten classifyError regex and add shutdown guard

### DIFF
--- a/src/classify-error.ts
+++ b/src/classify-error.ts
@@ -1,0 +1,72 @@
+/** Error codes for structured error responses (MCP 2025-06-18). */
+export type ErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'API_ERROR'
+  | 'TIMEOUT'
+  | 'RATE_LIMITED'
+  | 'PAYMENT_REQUIRED'
+  | 'CANCELLED'
+  | 'UNKNOWN';
+
+/**
+ * Classify an error into a structured error code.
+ * Inspects the error message and known error types to determine the category.
+ *
+ * Ordering matters: more specific checks (timeout, cancellation) come before
+ * broader ones (HTTP/API) to avoid mis-classification. In particular, timeout
+ * is checked before cancellation so that ECONNABORTED (which contains "aborted")
+ * is correctly classified as TIMEOUT rather than CANCELLED.
+ */
+export function classifyError(error: unknown): ErrorCode {
+  if (!error) return 'UNKNOWN';
+
+  const name = error instanceof Error ? error.name : '';
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+
+  // Timeout (checked before cancellation so ECONNABORTED → TIMEOUT, not CANCELLED)
+  if (
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('etimedout') ||
+    msg.includes('econnaborted')
+  ) {
+    return 'TIMEOUT';
+  }
+
+  // Cancellation (from MCP notifications/cancelled)
+  if (name === 'CancellationError' || msg.includes('cancelled') || msg.includes('aborted')) {
+    return 'CANCELLED';
+  }
+
+  // Validation errors (client-side input validation)
+  if (
+    msg.includes('is required') ||
+    msg.includes('must be') ||
+    msg.includes('cannot be empty') ||
+    msg.includes('invalid characters') ||
+    msg.includes('exceeds') ||
+    msg.includes('not a valid') ||
+    msg.includes('no valid update fields')
+  ) {
+    return 'VALIDATION_ERROR';
+  }
+
+  // Rate limiting — match "HTTP 429" pattern or descriptive phrases, not bare "429"
+  if (/\bhttp\s+429\b/.test(msg) || msg.includes('rate limit') || msg.includes('too many requests')) {
+    return 'RATE_LIMITED';
+  }
+
+  // Payment required (x402) — match "HTTP 402" pattern or descriptive phrases, not bare "402"
+  if (/\bhttp\s+402\b/.test(msg) || msg.includes('payment required') || msg.includes('x402')) {
+    return 'PAYMENT_REQUIRED';
+  }
+
+  // HTTP/API errors — match "HTTP" or "status" keywords only; the standalone
+  // /\b[45]\d{2}\b/ regex was removed because it false-matched non-HTTP numbers
+  // like "port 4500" or "limit of 500" (see issue #153).
+  if (msg.includes('http') || msg.includes('status')) {
+    return 'API_ERROR';
+  }
+
+  return 'UNKNOWN';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { createCompletionHandler } from './completions.js';
 import { mcpLogger } from './logging.js';
 import type { LogLevel } from './logging.js';
 import { RateLimiter, loadRateLimitConfig, getClientIp } from './rate-limiter.js';
+import { classifyError } from './classify-error.js';
 
 // Read version from package.json to avoid duplication
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -196,73 +197,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     };
   }
 });
-
-/** Error codes for structured error responses (MCP 2025-06-18). */
-type ErrorCode =
-  | 'VALIDATION_ERROR'
-  | 'API_ERROR'
-  | 'TIMEOUT'
-  | 'RATE_LIMITED'
-  | 'PAYMENT_REQUIRED'
-  | 'CANCELLED'
-  | 'UNKNOWN';
-
-/**
- * Classify an error into a structured error code.
- * Inspects the error message and known error types to determine the category.
- */
-function classifyError(error: unknown): ErrorCode {
-  if (!error) return 'UNKNOWN';
-
-  const name = error instanceof Error ? error.name : '';
-  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
-
-  // Cancellation (from MCP notifications/cancelled)
-  if (name === 'CancellationError' || msg.includes('cancelled') || msg.includes('aborted')) {
-    return 'CANCELLED';
-  }
-
-  // Validation errors (client-side input validation)
-  if (
-    msg.includes('is required') ||
-    msg.includes('must be') ||
-    msg.includes('cannot be empty') ||
-    msg.includes('invalid characters') ||
-    msg.includes('exceeds') ||
-    msg.includes('not a valid') ||
-    msg.includes('no valid update fields')
-  ) {
-    return 'VALIDATION_ERROR';
-  }
-
-  // Rate limiting
-  if (msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')) {
-    return 'RATE_LIMITED';
-  }
-
-  // Payment required (x402)
-  if (msg.includes('402') || msg.includes('payment required') || msg.includes('x402')) {
-    return 'PAYMENT_REQUIRED';
-  }
-
-  // Timeout
-  if (
-    msg.includes('timeout') ||
-    msg.includes('timed out') ||
-    msg.includes('etimedout') ||
-    msg.includes('econnaborted')
-  ) {
-    return 'TIMEOUT';
-  }
-
-  // HTTP/API errors
-  if (msg.includes('http') || msg.includes('status') || /\b[45]\d{2}\b/.test(msg)) {
-    return 'API_ERROR';
-  }
-
-  return 'UNKNOWN';
-}
-
 /**
  * Determine transport mode from CLI args and env vars.
  * --http or MEMOCLAW_TRANSPORT=http → Streamable HTTP
@@ -631,8 +565,11 @@ async function main() {
 
 main().catch(console.error);
 
-// Graceful shutdown
+// Graceful shutdown (guarded against double invocation from rapid SIGINT/SIGTERM)
+let _shuttingDown = false;
 function shutdown() {
+  if (_shuttingDown) return;
+  _shuttingDown = true;
   console.error('MemoClaw MCP server shutting down...');
   // Clean up HTTP sessions, sweep interval, and stop accepting connections
   _cleanupHttp?.();

--- a/tests/classify-error.test.ts
+++ b/tests/classify-error.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+
+// Set required env vars before importing index (which calls loadConfig on init)
+process.env.MEMOCLAW_PRIVATE_KEY = '0x4c0883a69102937d6231471b5dbb6204fe512961708279f15a8f7e20b4e3b1fb';
+
+import { classifyError } from '../src/classify-error.js';
+
+describe('classifyError', () => {
+  it('returns UNKNOWN for falsy input', () => {
+    expect(classifyError(null)).toBe('UNKNOWN');
+    expect(classifyError(undefined)).toBe('UNKNOWN');
+    expect(classifyError('')).toBe('UNKNOWN');
+    expect(classifyError(0)).toBe('UNKNOWN');
+  });
+
+  // --- Timeout (must come before cancellation tests) ---
+  it('classifies timeout errors', () => {
+    expect(classifyError(new Error('Request timed out after 30000ms'))).toBe('TIMEOUT');
+    expect(classifyError(new Error('Connection timeout'))).toBe('TIMEOUT');
+    expect(classifyError(new Error('ETIMEDOUT'))).toBe('TIMEOUT');
+  });
+
+  it('classifies ECONNABORTED as TIMEOUT, not CANCELLED', () => {
+    // ECONNABORTED contains "aborted" which previously matched CANCELLED
+    expect(classifyError(new Error('ECONNABORTED'))).toBe('TIMEOUT');
+  });
+
+  // --- Cancellation ---
+  it('classifies CancellationError by name', () => {
+    const err = new Error('something');
+    err.name = 'CancellationError';
+    expect(classifyError(err)).toBe('CANCELLED');
+  });
+
+  it('classifies "cancelled" in message', () => {
+    expect(classifyError(new Error('Request cancelled by client'))).toBe('CANCELLED');
+  });
+
+  it('classifies "aborted" in message (non-ECONNABORTED)', () => {
+    expect(classifyError(new Error('The operation was aborted'))).toBe('CANCELLED');
+  });
+
+  // --- Validation ---
+  it('classifies validation errors', () => {
+    expect(classifyError(new Error('id is required'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('importance must be a number'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('content cannot be empty'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('namespace contains invalid characters'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('content exceeds 8192 character limit'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('foo is not a valid date'))).toBe('VALIDATION_ERROR');
+    expect(classifyError(new Error('no valid update fields'))).toBe('VALIDATION_ERROR');
+  });
+
+  // --- Rate limiting ---
+  it('classifies HTTP 429 as RATE_LIMITED', () => {
+    expect(classifyError(new Error('HTTP 429: Too Many Requests'))).toBe('RATE_LIMITED');
+    expect(classifyError(new Error('http 429'))).toBe('RATE_LIMITED');
+  });
+
+  it('classifies rate limit phrases', () => {
+    expect(classifyError(new Error('rate limit exceeded'))).toBe('RATE_LIMITED');
+    expect(classifyError(new Error('too many requests'))).toBe('RATE_LIMITED');
+  });
+
+  it('does NOT false-match bare "429" without HTTP prefix', () => {
+    expect(classifyError(new Error('connected to port 429'))).not.toBe('RATE_LIMITED');
+    expect(classifyError(new Error('item 429 not found'))).not.toBe('RATE_LIMITED');
+  });
+
+  // --- Payment required ---
+  it('classifies HTTP 402 as PAYMENT_REQUIRED', () => {
+    expect(classifyError(new Error('HTTP 402: Payment Required'))).toBe('PAYMENT_REQUIRED');
+    expect(classifyError(new Error('http 402'))).toBe('PAYMENT_REQUIRED');
+  });
+
+  it('classifies payment phrases', () => {
+    expect(classifyError(new Error('payment required'))).toBe('PAYMENT_REQUIRED');
+    expect(classifyError(new Error('x402 payment needed'))).toBe('PAYMENT_REQUIRED');
+  });
+
+  it('does NOT false-match bare "402" without HTTP prefix', () => {
+    expect(classifyError(new Error('room 402 is unavailable'))).not.toBe('PAYMENT_REQUIRED');
+  });
+
+  // --- API errors ---
+  it('classifies HTTP errors as API_ERROR', () => {
+    expect(classifyError(new Error('HTTP 500: Internal Server Error'))).toBe('API_ERROR');
+    expect(classifyError(new Error('HTTP 503: Service Unavailable'))).toBe('API_ERROR');
+    expect(classifyError(new Error('bad status code'))).toBe('API_ERROR');
+  });
+
+  it('does NOT false-match non-HTTP numbers (issue #153)', () => {
+    expect(classifyError(new Error('port 4500 unavailable'))).toBe('UNKNOWN');
+    expect(classifyError(new Error('error code 404'))).toBe('UNKNOWN');
+    expect(classifyError(new Error('allocated 512 bytes'))).toBe('UNKNOWN');
+  });
+
+  // --- UNKNOWN fallback ---
+  it('returns UNKNOWN for unrecognized errors', () => {
+    expect(classifyError(new Error('something went wrong'))).toBe('UNKNOWN');
+    expect(classifyError('a plain string error')).toBe('UNKNOWN');
+    expect(classifyError(42)).toBe('UNKNOWN');
+  });
+
+  // --- String input ---
+  it('handles string input (non-Error)', () => {
+    expect(classifyError('HTTP 500: oops')).toBe('API_ERROR');
+    expect(classifyError('request cancelled')).toBe('CANCELLED');
+  });
+});


### PR DESCRIPTION
## Changes

- **Fix classifyError false-matches (Fixes #153)**: Removed the standalone `/\b[45]\d{2}\b/` regex from API_ERROR detection that could false-match non-HTTP numbers like `port 4500` or `limit of 500`
- **Tighten 429/402 matching**: Replaced bare `'429'`/`'402'` string includes with `/\bhttp\s+NNN\b/` regex patterns so messages like `'room 402'` or `'item 429'` aren't misclassified
- **Fix ECONNABORTED classification**: Moved timeout check before cancellation so `ECONNABORTED` (which contains `aborted`) is correctly classified as `TIMEOUT` instead of `CANCELLED`
- **Double-shutdown guard**: Added `_shuttingDown` flag to prevent issues from rapid SIGINT/SIGTERM signals
- **Test coverage**: Added 17 comprehensive tests for `classifyError` covering all error categories and false-match prevention

## Testing

All 541 tests pass. No formatting/lint issues.