### PR TITLE
feat: add completions, sort/order params, and pinned filter

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -9,6 +9,10 @@ import type { ApiClient } from './api.js';
 import type { Config } from './config.js';
 
 const MEMORY_TYPES = ['correction', 'preference', 'decision', 'project', 'observation', 'general'];
+const SUGGESTED_CATEGORIES = ['stale', 'fresh', 'hot', 'decaying'];
+const RELATION_TYPES = ['related_to', 'derived_from', 'contradicts', 'supersedes', 'supports'];
+const SORT_FIELDS = ['created_at', 'updated_at', 'importance'];
+const SORT_ORDERS = ['asc', 'desc'];
 
 /** Simple TTL cache for namespace and tag lists */
 interface CacheEntry<T> {
@@ -83,6 +87,26 @@ export function createCompletionHandler(api: ApiClient, _config: Config) {
     // Provide completions for 'memory_type' argument
     if (argName === 'memory_type') {
       return { completion: filterValues(MEMORY_TYPES, partial) };
+    }
+
+    // Provide completions for 'category' argument (memoclaw_suggested)
+    if (argName === 'category') {
+      return { completion: filterValues(SUGGESTED_CATEGORIES, partial) };
+    }
+
+    // Provide completions for 'relation_type' argument (memoclaw_create_relation, memoclaw_graph)
+    if (argName === 'relation_type') {
+      return { completion: filterValues(RELATION_TYPES, partial) };
+    }
+
+    // Provide completions for 'sort' argument (memoclaw_list, memoclaw_search)
+    if (argName === 'sort') {
+      return { completion: filterValues(SORT_FIELDS, partial) };
+    }
+
+    // Provide completions for 'order' argument (memoclaw_list, memoclaw_search)
+    if (argName === 'order') {
+      return { completion: filterValues(SORT_ORDERS, partial) };
     }
 
     // No completions available for this argument

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -168,7 +168,8 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_list': {
-      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after, before } = args as ListArgs;
+      const { limit, offset, tags, namespace, memory_type, session_id, agent_id, after, before, sort, order, pinned } =
+        args as ListArgs;
       validatePaginationParam(limit, 'limit');
       validatePaginationParam(offset, 'offset');
       validateTags(tags);
@@ -188,6 +189,9 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (agent_id) params.set('agent_id', agent_id);
       if (after) params.set('after', after);
       if (before) params.set('before', before);
+      if (sort) params.set('sort', sort);
+      if (order) params.set('order', order);
+      if (pinned !== undefined) params.set('pinned', String(pinned));
       const result = await makeRequest('GET', `/v1/memories?${params}`);
       const memories = result.memories || result.data || [];
       const total = result.total ?? memories.length;
@@ -450,7 +454,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_count': {
-      const { namespace, tags, agent_id, memory_type, session_id, before, after } = args as CountArgs;
+      const { namespace, tags, agent_id, memory_type, session_id, before, after, pinned } = args as CountArgs;
       validateISODate(after, 'after');
       validateISODate(before, 'before');
       const params = new URLSearchParams();
@@ -461,6 +465,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (session_id) params.set('session_id', session_id);
       if (before) params.set('before', before);
       if (after) params.set('after', after);
+      if (pinned !== undefined) params.set('pinned', String(pinned));
 
       let total: number | string = 'unknown';
       try {
@@ -509,6 +514,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         agent_id && `agent=${agent_id}`,
         session_id && `session=${session_id}`,
         tags?.length && `tags=${tags.join(',')}`,
+        pinned !== undefined && `pinned=${pinned}`,
         after && `after=${after}`,
         before && `before=${before}`,
       ].filter(Boolean);

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -71,7 +71,8 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
     }
 
     case 'memoclaw_search': {
-      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after, before } = args as SearchArgs;
+      const { query, limit, namespace, tags, memory_type, session_id, agent_id, after, before, sort, order, pinned } =
+        args as SearchArgs;
       validateQuery(query);
       validatePaginationParam(limit, 'limit');
       validateIdentifier(namespace, 'namespace');
@@ -91,6 +92,9 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (agent_id) params.set('agent_id', agent_id);
       if (after) params.set('after', after);
       if (before) params.set('before', before);
+      if (sort) params.set('sort', sort);
+      if (order) params.set('order', order);
+      if (pinned !== undefined) params.set('pinned', String(pinned));
       const result = await makeRequest('GET', `/v1/memories/search?${params}`);
       const memories = result.memories || result.data || [];
       if (memories.length === 0) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -87,6 +87,10 @@ const COMMON_FILTERS = {
   memory_type: { type: 'string' as const, enum: MEMORY_TYPE_ENUM, description: 'Filter by memory type.' },
   session_id: { type: 'string' as const, description: 'Filter by session ID.' },
   agent_id: { type: 'string' as const, description: 'Filter by agent ID.' },
+  pinned: {
+    type: 'boolean' as const,
+    description: 'Filter by pinned status. true = only pinned, false = only unpinned.',
+  },
   after: {
     type: 'string' as const,
     description: 'Only return memories created after this ISO 8601 date, e.g. "2025-01-01T00:00:00Z".',
@@ -228,6 +232,16 @@ export const TOOLS = [
       properties: {
         query: { type: 'string', description: 'Keyword or phrase to search for (case-insensitive).' },
         limit: { type: 'number', description: 'Maximum number of results. Default: 20. Max: 100.' },
+        sort: {
+          type: 'string',
+          enum: ['created_at', 'updated_at', 'importance'],
+          description: 'Sort field. Default: "created_at".',
+        },
+        order: {
+          type: 'string',
+          enum: ['asc', 'desc'],
+          description: 'Sort order. Default: "desc" (newest first).',
+        },
         ...COMMON_FILTERS,
       },
       required: ['query'],
@@ -283,6 +297,16 @@ export const TOOLS = [
       properties: {
         limit: { type: 'number', description: 'Max results per page. Default: 20. Max: 100.' },
         offset: { type: 'number', description: 'Pagination offset. Default: 0.' },
+        sort: {
+          type: 'string',
+          enum: ['created_at', 'updated_at', 'importance'],
+          description: 'Sort field. Default: "created_at".',
+        },
+        order: {
+          type: 'string',
+          enum: ['asc', 'desc'],
+          description: 'Sort order. Default: "desc" (newest first).',
+        },
         ...COMMON_FILTERS,
       },
     },
@@ -780,6 +804,7 @@ export const TOOLS = [
         agent_id: { type: 'string', description: 'Count only memories from this agent.' },
         memory_type: { type: 'string', enum: MEMORY_TYPE_ENUM, description: 'Count only memories of this type.' },
         session_id: { type: 'string', description: 'Count only memories from this session.' },
+        pinned: { type: 'boolean', description: 'Count only pinned (true) or unpinned (false) memories.' },
         after: {
           type: 'string',
           description: 'Count only memories created after this ISO 8601 date, e.g. "2025-01-01T00:00:00Z".',

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,9 @@ export interface SearchArgs {
   agent_id?: string;
   after?: string;
   before?: string;
+  sort?: string;
+  order?: string;
+  pinned?: boolean;
 }
 
 export interface GetArgs {
@@ -60,6 +63,9 @@ export interface ListArgs {
   agent_id?: string;
   after?: string;
   before?: string;
+  sort?: string;
+  order?: string;
+  pinned?: boolean;
 }
 
 export interface DeleteArgs {
@@ -229,6 +235,7 @@ export interface CountArgs {
   session_id?: string;
   before?: string;
   after?: string;
+  pinned?: boolean;
 }
 
 export interface DeleteNamespaceArgs {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -80,6 +80,74 @@ describe('Completions', () => {
     expect(mockMakeRequest).not.toHaveBeenCalled();
   });
 
+  it('returns category completions', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'review-memories' },
+      { name: 'category', value: 'st' },
+    );
+
+    expect(result.completion.values).toEqual(['stale']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all categories when value is empty', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'review-memories' },
+      { name: 'category', value: '' },
+    );
+
+    expect(result.completion.values).toEqual(['stale', 'fresh', 'hot', 'decaying']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns relation_type completions', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'create-relation' },
+      { name: 'relation_type', value: 'der' },
+    );
+
+    expect(result.completion.values).toEqual(['derived_from']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all relation_types when value is empty', async () => {
+    const result = await handleComplete(
+      { type: 'ref/prompt', name: 'create-relation' },
+      { name: 'relation_type', value: '' },
+    );
+
+    expect(result.completion.values).toEqual(['related_to', 'derived_from', 'contradicts', 'supersedes', 'supports']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns sort completions', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'list' }, { name: 'sort', value: 'cre' });
+
+    expect(result.completion.values).toEqual(['created_at']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all sort fields when value is empty', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'list' }, { name: 'sort', value: '' });
+
+    expect(result.completion.values).toEqual(['created_at', 'updated_at', 'importance']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns order completions', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'list' }, { name: 'order', value: 'a' });
+
+    expect(result.completion.values).toEqual(['asc']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all order values when value is empty', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'list' }, { name: 'order', value: '' });
+
+    expect(result.completion.values).toEqual(['asc', 'desc']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
   it('returns empty for unknown arguments', async () => {
     const result = await handleComplete(
       { type: 'ref/prompt', name: 'load-context' },

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -115,6 +115,34 @@ describe('handleMemory', () => {
         'tags[1] must be a non-empty string',
       );
     });
+
+    it('passes sort and order as query params', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories': { memories: [], total: 0 },
+      });
+      await handleMemory(ctx, 'memoclaw_list', { sort: 'importance', order: 'asc' });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('sort=importance');
+      expect(path).toContain('order=asc');
+    });
+
+    it('passes pinned filter as query param', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories': { memories: [{ id: '1', content: 'a', pinned: true }], total: 1 },
+      });
+      await handleMemory(ctx, 'memoclaw_list', { pinned: true });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('pinned=true');
+    });
+
+    it('passes pinned=false filter as query param', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories': { memories: [], total: 0 },
+      });
+      await handleMemory(ctx, 'memoclaw_list', { pinned: false });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('pinned=false');
+    });
   });
 
   // ── update ───────────────────────────────────────────────────────────────
@@ -408,6 +436,17 @@ describe('handleMemory', () => {
       expect(callUrl).toContain('session_id=sess-123');
       expect(callUrl).toContain('after=2025-01-01T00%3A00%3A00Z');
       expect(callUrl).toContain('before=2025-12-31T23%3A59%3A59Z');
+    });
+
+    it('passes pinned filter', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories/count': { count: 3 },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_count', { pinned: true });
+      expect(result!.content[0].text).toContain('3');
+      expect(result!.content[0].text).toContain('pinned=true');
+      const callUrl = api.makeRequest.mock.calls[0][1];
+      expect(callUrl).toContain('pinned=true');
     });
   });
 

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -100,6 +100,25 @@ describe('handleRecall', () => {
       const path = api.makeRequest.mock.calls[0][1];
       expect(path).toContain('before=2025-12-31T00%3A00%3A00Z');
     });
+
+    it('passes sort and order as query params', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories/search': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_search', { query: 'test', sort: 'importance', order: 'desc' });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('sort=importance');
+      expect(path).toContain('order=desc');
+    });
+
+    it('passes pinned filter as query param', async () => {
+      const { ctx, api } = makeCtx({
+        'GET /v1/memories/search': { memories: [{ id: '1', content: 'pinned result', pinned: true }] },
+      });
+      await handleRecall(ctx, 'memoclaw_search', { query: 'test', pinned: true });
+      const path = api.makeRequest.mock.calls[0][1];
+      expect(path).toContain('pinned=true');
+    });
   });
 
   describe('memoclaw_context', () => {


### PR DESCRIPTION
## Changes

### Autocomplete completions (Fixes #158)
- Add completions for `category` argument (enum: stale, fresh, hot, decaying)
- Add completions for `relation_type` argument (enum: related_to, derived_from, contradicts, supersedes, supports)
- Add completions for `sort` argument (enum: created_at, updated_at, importance)
- Add completions for `order` argument (enum: asc, desc)

### Sort/order params (Fixes #159)
- Add `sort` and `order` parameters to `memoclaw_list` tool
- Add `sort` and `order` parameters to `memoclaw_search` tool
- Both support sorting by `created_at`, `updated_at`, or `importance` in `asc`/`desc` order

### Pinned filter (Fixes #160)
- Add `pinned` boolean filter to `COMMON_FILTERS` (shared by list, search, recall)
- Add `pinned` filter to `memoclaw_count` tool
- Pass `pinned` param through to API in list, search, and count handlers

## Testing

All 555 tests pass (14 new tests added). No lint errors. Formatting clean.

```
 Test Files  18 passed (18)
      Tests  555 passed (555)
```