### PR TITLE
fix: propagate MCP cancellation signal to API fetch calls

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -48,20 +48,35 @@ export function createApiClient(config: Config) {
     return new Promise((resolve) => setTimeout(resolve, delay));
   }
 
-  async function makeRequest(method: string, path: string, body?: any) {
+  async function makeRequest(method: string, path: string, body?: any, externalSignal?: AbortSignal) {
     const url = `${apiUrl}${path}`;
     const { timeout, maxRetries } = config;
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      // Bail out immediately if already cancelled before starting the attempt
+      if (externalSignal?.aborted) {
+        const err = new Error('Operation cancelled by client');
+        err.name = 'CancellationError';
+        throw err;
+      }
+
       if (attempt > 0) {
         mcpLogger.debug('api', { event: 'retry', method, path, attempt });
         await backoff(attempt - 1);
       }
 
+      let onExternalAbort: (() => void) | undefined;
       try {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), timeout);
+
+        // If an external signal (e.g. MCP cancellation) is provided, abort
+        // the fetch when either the timeout or the external signal fires.
+        if (externalSignal && !externalSignal.aborted) {
+          onExternalAbort = () => controller.abort();
+          externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+        }
 
         const headers: Record<string, string> = {};
         if (body) {
@@ -80,6 +95,7 @@ export function createApiClient(config: Config) {
         });
 
         clearTimeout(timer);
+        if (onExternalAbort) externalSignal!.removeEventListener('abort', onExternalAbort);
 
         // Handle 402 Payment Required (free tier exhausted) — no retry needed
         if (res.status === 402) {
@@ -103,6 +119,11 @@ export function createApiClient(config: Config) {
 
           const controller2 = new AbortController();
           const timer2 = setTimeout(() => controller2.abort(), timeout);
+          let onExternalAbort2: (() => void) | undefined;
+          if (externalSignal && !externalSignal.aborted) {
+            onExternalAbort2 = () => controller2.abort();
+            externalSignal.addEventListener('abort', onExternalAbort2, { once: true });
+          }
 
           res = await fetch(url, {
             method,
@@ -112,6 +133,7 @@ export function createApiClient(config: Config) {
           });
 
           clearTimeout(timer2);
+          if (onExternalAbort2) externalSignal!.removeEventListener('abort', onExternalAbort2);
         }
 
         // Retry on transient server errors
@@ -127,6 +149,16 @@ export function createApiClient(config: Config) {
 
         return res.json();
       } catch (err: any) {
+        // Clean up listeners on error paths
+        if (onExternalAbort) externalSignal!.removeEventListener('abort', onExternalAbort);
+
+        // If the external signal caused the abort, surface it as cancellation (no retry)
+        if (err.name === 'AbortError' && externalSignal?.aborted) {
+          const cancelErr = new Error('Operation cancelled by client');
+          cancelErr.name = 'CancellationError';
+          throw cancelErr;
+        }
+
         // Retry on network errors and timeouts (but not client errors)
         if (err.name === 'AbortError') {
           lastError = new Error(`Request timed out after ${timeout}ms`);

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -79,12 +79,16 @@ export function createContext(
   progress?: ProgressCallback,
   signal?: AbortSignal,
 ): HandlerContext {
+  const resolvedSignal = signal || new AbortController().signal;
   return {
     api,
     config,
-    makeRequest: api.makeRequest,
+    // Wrap makeRequest to automatically forward the MCP cancellation signal
+    // to every API call, so in-flight fetch() requests abort immediately
+    // when the client sends notifications/cancelled.
+    makeRequest: (method: string, path: string, body?: any) => api.makeRequest(method, path, body, resolvedSignal),
     account: api.account,
     progress: progress || (async () => {}),
-    signal: signal || new AbortController().signal,
+    signal: resolvedSignal,
   };
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -227,4 +227,81 @@ describe('API Client', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('external signal (MCP cancellation)', () => {
+    it('aborts immediately when external signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const client = createApiClient({ ...config, maxRetries: 0 });
+      await expect(client.makeRequest('GET', '/v1/memories', undefined, controller.signal)).rejects.toThrow(
+        'Operation cancelled by client',
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('aborts in-flight fetch when external signal fires', async () => {
+      const controller = new AbortController();
+      // Simulate a long-running fetch that responds to abort
+      fetchSpy.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+          }),
+      );
+
+      const client = createApiClient({ ...config, timeout: 30000, maxRetries: 0 });
+      const promise = client.makeRequest('GET', '/v1/memories', undefined, controller.signal);
+
+      // Give the fetch a moment to start, then cancel
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      await expect(promise).rejects.toThrow('Operation cancelled by client');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CancellationError (not timeout) when external signal aborts', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+          }),
+      );
+
+      const client = createApiClient({ ...config, timeout: 30000, maxRetries: 0 });
+      const promise = client.makeRequest('GET', '/v1/memories', undefined, controller.signal);
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      try {
+        await promise;
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err.name).toBe('CancellationError');
+        expect(err.message).toContain('cancelled');
+      }
+    });
+
+    it('does not retry when cancelled via external signal', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockImplementation(
+        (_url: string, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+          }),
+      );
+
+      const client = createApiClient({ ...config, timeout: 30000, maxRetries: 3 });
+      const promise = client.makeRequest('GET', '/v1/memories', undefined, controller.signal);
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      await expect(promise).rejects.toThrow('Operation cancelled by client');
+      // Should NOT retry — only 1 fetch call
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When a user cancels a long-running operation via MCP `notifications/cancelled`, the `AbortSignal` was only checked between loop iterations in handlers. Individual in-flight `fetch()` calls in `makeRequest()` were **not** aborted — they would run until the timeout (default 30s), wasting time and API credits.

## Changes

- `makeRequest()` now accepts an optional `externalSignal` parameter
- The signal is composed with the internal timeout abort: if either fires, the fetch is aborted immediately
- `CancellationError` is thrown (not retried) when the external signal causes the abort
- `createContext()` wraps `makeRequest` to auto-forward the MCP protocol signal to every API call
- Added 4 tests covering: pre-aborted signals, in-flight abort, error type distinction, and no-retry-on-cancel

## Impact

All long-running operations (`consolidate`, `ingest`, `migrate`, `export`, `delete_namespace`) now abort within milliseconds of cancellation instead of hanging for up to 30s.

Fixes #162