### PR TITLE
feat: add metadata parameter to memoclaw_store

### DIFF
--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -121,7 +121,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
   switch (name) {
     case 'memoclaw_store': {
-      const { content, importance, tags, namespace, memory_type, session_id, agent_id, expires_at, pinned, immutable } =
+      const { content, importance, tags, namespace, memory_type, session_id, agent_id, expires_at, pinned, immutable, metadata } =
         args as StoreArgs;
       if (!content || (typeof content === 'string' && content.trim() === '')) {
         throw new Error('content is required and cannot be empty');
@@ -144,6 +144,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       if (expires_at) body.expires_at = expires_at;
       if (pinned !== undefined) body.pinned = pinned;
       if (immutable !== undefined) body.immutable = immutable;
+      if (metadata !== undefined) body.metadata = metadata;
       const result = await makeRequest('POST', '/v1/store', body);
       const memory = result.memory || result;
       return {
@@ -314,7 +315,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       return bulkStoreWithFallback(
         ctx,
         memories,
-        ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'expires_at', 'immutable'],
+        ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'expires_at', 'immutable', 'metadata'],
         '✅ Bulk store',
         session_id,
         agent_id,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -160,6 +160,11 @@ export const TOOLS = [
           description:
             'If true, this memory cannot be updated or deleted after creation. This is a one-way operation and cannot be reversed.',
         },
+        metadata: {
+          type: 'object',
+          description:
+            'Arbitrary key-value metadata to attach to this memory. Useful for storing structured data alongside the content, e.g. {"source": "slack", "channel": "#general"}.',
+        },
       },
       required: ['content'],
     },
@@ -764,6 +769,7 @@ export const TOOLS = [
               memory_type: { type: 'string', enum: MEMORY_TYPE_ENUM, description: 'Memory type.' },
               pinned: { type: 'boolean', description: 'Pin to prevent decay.' },
               immutable: { type: 'boolean', description: 'Make this memory immutable (one-way, cannot be reversed).' },
+              metadata: { type: 'object', description: 'Arbitrary key-value metadata.' },
             },
             required: ['content'],
           },

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface StoreArgs {
   expires_at?: string;
   pinned?: boolean;
   immutable?: boolean;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RecallArgs {
@@ -121,6 +122,7 @@ export interface BulkStoreMemory {
   pinned?: boolean;
   expires_at?: string;
   immutable?: boolean;
+  metadata?: Record<string, unknown>;
 }
 
 export interface BulkStoreArgs {

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -57,6 +57,28 @@ describe('handleMemory', () => {
       expect(body.pinned).toBe(true);
       expect(body.immutable).toBe(true);
     });
+
+    it('passes metadata to the API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/store': { memory: { id: '1', content: 'test', metadata: { source: 'slack' } } },
+      });
+      const result = await handleMemory(ctx, 'memoclaw_store', {
+        content: 'test',
+        metadata: { source: 'slack', channel: '#general' },
+      });
+      expect(result).not.toBeNull();
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.metadata).toEqual({ source: 'slack', channel: '#general' });
+    });
+
+    it('omits metadata when not provided', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/store': { memory: { id: '1', content: 'test' } },
+      });
+      await handleMemory(ctx, 'memoclaw_store', { content: 'test' });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.metadata).toBeUndefined();
+    });
   });
 
   // ── get ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`memoclaw_store` and `memoclaw_bulk_store` were missing support for the `metadata` parameter, even though `memoclaw_update` already supported it. This made it impossible to attach structured metadata at creation time — users had to store first, then immediately update to add metadata.

## Changes

- Added optional `metadata` (`Record<string, unknown>`) to `StoreArgs` and `BulkStoreMemory` types
- Added `metadata` to `memoclaw_store` and `memoclaw_bulk_store` tool input schemas with description
- Handler now passes `metadata` through to the API when provided
- Added `metadata` to the bulk store fields list
- 2 new tests: metadata forwarded to API, metadata omitted when undefined

## Example

```json
{
  "content": "User prefers dark mode",
  "importance": 0.7,
  "metadata": {
    "source": "slack",
    "channel": "#general",
    "thread_ts": "1234567890.123456"
  }
}
```

Fixes #163