### PR TITLE
fix: import fields, batch validation, graph depth, vitest config

### DIFF
--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -121,8 +121,19 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
 
   switch (name) {
     case 'memoclaw_store': {
-      const { content, importance, tags, namespace, memory_type, session_id, agent_id, expires_at, pinned, immutable, metadata } =
-        args as StoreArgs;
+      const {
+        content,
+        importance,
+        tags,
+        namespace,
+        memory_type,
+        session_id,
+        agent_id,
+        expires_at,
+        pinned,
+        immutable,
+        metadata,
+      } = args as StoreArgs;
       if (!content || (typeof content === 'string' && content.trim() === '')) {
         throw new Error('content is required and cannot be empty');
       }
@@ -338,7 +349,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       return bulkStoreWithFallback(
         ctx,
         memories,
-        ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'immutable'],
+        ['content', 'importance', 'tags', 'namespace', 'memory_type', 'pinned', 'immutable', 'expires_at', 'metadata'],
         '📥 Import',
         session_id,
         agent_id,
@@ -405,6 +416,14 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
         };
       } catch (err: any) {
         if (err.message?.includes('404') || err.message?.includes('Not Found')) {
+          // Validate fields before sending individual requests (mirrors memoclaw_update validation)
+          for (const u of updates) {
+            if (typeof u.content === 'string') validateContentLength(u.content);
+            validateIdentifier(u.namespace, 'namespace');
+            validateIdentifier(u.memory_type, 'memory_type');
+            validateTags(u.tags);
+            validateISODate(u.expires_at as string | undefined, 'expires_at');
+          }
           let updateProgress = 0;
           const results = await withConcurrency(
             updates.map((u: any) => async () => {

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -67,6 +67,11 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
       const { memory_id, depth: rawDepth, relation_type } = args as GraphArgs;
       validateId(memory_id, 'memory_id');
       if (relation_type) validateIdentifier(relation_type, 'relation_type');
+      if (rawDepth !== undefined && rawDepth !== null) {
+        if (typeof rawDepth !== 'number' || !Number.isInteger(rawDepth) || rawDepth < 1) {
+          throw new Error('depth must be a positive integer (1-3)');
+        }
+      }
       const depth = Math.min(Math.max(rawDepth || 1, 1), 3);
       const visited = new Set<string>();
       const nodes: any[] = [];

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -722,6 +722,11 @@ export const TOOLS = [
               memory_type: { type: 'string', description: 'Memory type.' },
               pinned: { type: 'boolean', description: 'Pin status.' },
               immutable: { type: 'boolean', description: 'Make this memory immutable.' },
+              expires_at: {
+                type: 'string',
+                description: 'Expiration date in ISO 8601 format, e.g. "2025-12-31T23:59:59Z".',
+              },
+              metadata: { type: 'object', description: 'Arbitrary key-value metadata.' },
             },
             required: ['content'],
           },

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,8 @@ export interface ImportMemory {
   memory_type?: string;
   pinned?: boolean;
   immutable?: boolean;
+  expires_at?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ImportArgs {

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -347,6 +347,27 @@ describe('handleMemory', () => {
       const { ctx } = makeCtx();
       await expect(handleMemory(ctx, 'memoclaw_import', { memories: [] })).rejects.toThrow('non-empty array');
     });
+
+    it('passes metadata and expires_at fields to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/store/batch': (_path: string, body: any) => ({
+          memories: body.memories.map((m: any, i: number) => ({ id: String(i), ...m })),
+          failed: [],
+        }),
+      });
+      await handleMemory(ctx, 'memoclaw_import', {
+        memories: [
+          {
+            content: 'test memory',
+            metadata: { source: 'migration' },
+            expires_at: '2026-12-31T23:59:59Z',
+          },
+        ],
+      });
+      const callBody = api.makeRequest.mock.calls[0][2];
+      expect(callBody.memories[0].metadata).toEqual({ source: 'migration' });
+      expect(callBody.memories[0].expires_at).toBe('2026-12-31T23:59:59Z');
+    });
   });
 
   // ── pin / unpin ──────────────────────────────────────────────────────────
@@ -407,6 +428,33 @@ describe('handleMemory', () => {
           updates: [{ content: 'no id' }],
         }),
       ).rejects.toThrow('missing "id"');
+    });
+
+    it('validates content length in fallback path', async () => {
+      const longContent = 'x'.repeat(9000);
+      const api = mockApiWithErrors(
+        { 'PATCH /v1/memories/': { memory: { id: '1', content: 'ok' } } },
+        { 'POST /v1/memories/batch-update': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      await expect(
+        handleMemory(ctx, 'memoclaw_batch_update', {
+          updates: [{ id: '1', content: longContent }],
+        }),
+      ).rejects.toThrow('exceeds');
+    });
+
+    it('validates namespace in fallback path', async () => {
+      const api = mockApiWithErrors(
+        { 'PATCH /v1/memories/': { memory: { id: '1', content: 'ok' } } },
+        { 'POST /v1/memories/batch-update': new Error('HTTP 404: Not Found') },
+      );
+      const ctx = createContext(api as any, testConfig);
+      await expect(
+        handleMemory(ctx, 'memoclaw_batch_update', {
+          updates: [{ id: '1', namespace: 'invalid namespace!' }],
+        }),
+      ).rejects.toThrow('invalid characters');
     });
 
     it('validates tags in individual updates', async () => {

--- a/tests/handlers/relations.test.ts
+++ b/tests/handlers/relations.test.ts
@@ -100,6 +100,27 @@ describe('handleRelations', () => {
       await expect(handleRelations(ctx, 'memoclaw_graph', {})).rejects.toThrow('memory_id is required');
     });
 
+    it('rejects non-integer depth', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_graph', { memory_id: 'm1', depth: 2.5 })).rejects.toThrow(
+        'depth must be a positive integer',
+      );
+    });
+
+    it('rejects zero depth', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_graph', { memory_id: 'm1', depth: 0 })).rejects.toThrow(
+        'depth must be a positive integer',
+      );
+    });
+
+    it('rejects negative depth', async () => {
+      const { ctx } = makeCtx();
+      await expect(handleRelations(ctx, 'memoclaw_graph', { memory_id: 'm1', depth: -1 })).rejects.toThrow(
+        'depth must be a positive integer',
+      );
+    });
+
     it('clamps depth to 1-3', async () => {
       const { ctx } = makeCtx({
         'GET /v1/memories/': (path: string) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts'],
+      thresholds: {
+        statements: 80,
+        branches: 75,
+        functions: 80,
+        lines: 80,
+      },
+    },
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

Fixes #166, Fixes #167, Fixes #168, Fixes #169

### Changes

**#166 — memoclaw_import missing metadata/expires_at**
- Added `expires_at` and `metadata` to `ImportMemory` type
- Updated import handler to pass these fields through to the API
- Updated tool schema with the new properties
- Added test verifying fields are passed to API

**#167 — batch_update fallback missing validation**
- Added `validateContentLength`, `validateIdentifier`, `validateTags`, and `validateISODate` calls in the batch_update 404 fallback path
- This matches the validation done by the main `memoclaw_update` handler
- Added tests for content length and namespace validation in fallback path

**#169 — graph depth not validated as integer**
- Added integer validation for `depth` parameter (must be positive integer 1-3)
- Values like 2.5, 0, or -1 now throw clear errors
- Added 3 test cases for invalid depth values

**#168 — vitest config with coverage thresholds**
- Added `vitest.config.ts` with v8 coverage provider
- Set thresholds: 80% statements/functions/lines, 75% branches
- Explicit test include/exclude patterns

### Test results
- All 567 tests pass (6 new tests)
- Prettier + ESLint clean
- Build succeeds