### PR TITLE
fix: pass pinned filter in memoclaw_recall and add format/strategy completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2026-03-10
+
+### Fixed
+- `memoclaw_recall` now passes the `pinned` filter to the API — previously the parameter was advertised in the tool schema (via COMMON_FILTERS) but silently ignored by the handler
+- Added `pinned` field to `RecallArgs` type definition
+
+### Added
+- Autocomplete completions for `format` argument (memoclaw_export: json, jsonl) and `strategy` argument (memoclaw_merge: keep_target, keep_source, combine)
+- 7 new tests covering recall pinned filter and new completions
+
 ## [1.17.0] - 2026-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "MCP server for MemoClaw semantic memory API. 100 free calls per wallet.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -13,6 +13,8 @@ const SUGGESTED_CATEGORIES = ['stale', 'fresh', 'hot', 'decaying'];
 const RELATION_TYPES = ['related_to', 'derived_from', 'contradicts', 'supersedes', 'supports'];
 const SORT_FIELDS = ['created_at', 'updated_at', 'importance'];
 const SORT_ORDERS = ['asc', 'desc'];
+const EXPORT_FORMATS = ['json', 'jsonl'];
+const MERGE_STRATEGIES = ['keep_target', 'keep_source', 'combine'];
 
 /** Simple TTL cache for namespace and tag lists */
 interface CacheEntry<T> {
@@ -107,6 +109,16 @@ export function createCompletionHandler(api: ApiClient, _config: Config) {
     // Provide completions for 'order' argument (memoclaw_list, memoclaw_search)
     if (argName === 'order') {
       return { completion: filterValues(SORT_ORDERS, partial) };
+    }
+
+    // Provide completions for 'format' argument (memoclaw_export)
+    if (argName === 'format') {
+      return { completion: filterValues(EXPORT_FORMATS, partial) };
+    }
+
+    // Provide completions for 'strategy' argument (memoclaw_merge)
+    if (argName === 'strategy') {
+      return { completion: filterValues(MERGE_STRATEGIES, partial) };
     }
 
     // No completions available for this argument

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -27,6 +27,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
         include_relations,
         after,
         before,
+        pinned,
       } = args as RecallArgs;
       validateQuery(query);
       validatePaginationParam(limit, 'limit');
@@ -43,6 +44,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       if (memory_type) filters.memory_type = memory_type;
       if (after) filters.after = after;
       if (before) filters.before = before;
+      if (pinned !== undefined) filters.pinned = pinned;
       const result = await makeRequest('POST', '/v1/recall', {
         query,
         limit,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface RecallArgs {
   include_relations?: boolean;
   after?: string;
   before?: string;
+  pinned?: boolean;
 }
 
 export interface SearchArgs {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -175,4 +175,32 @@ describe('Completions', () => {
 
     expect(result.completion.values).toEqual([]);
   });
+
+  it('returns format completions', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'export' }, { name: 'format', value: 'js' });
+
+    expect(result.completion.values).toEqual(['json', 'jsonl']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all format values when value is empty', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'export' }, { name: 'format', value: '' });
+
+    expect(result.completion.values).toEqual(['json', 'jsonl']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns strategy completions', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'merge' }, { name: 'strategy', value: 'keep' });
+
+    expect(result.completion.values).toEqual(['keep_target', 'keep_source']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns all strategy values when value is empty', async () => {
+    const result = await handleComplete({ type: 'ref/prompt', name: 'merge' }, { name: 'strategy', value: '' });
+
+    expect(result.completion.values).toEqual(['keep_target', 'keep_source', 'combine']);
+    expect(mockMakeRequest).not.toHaveBeenCalled();
+  });
 });

--- a/tests/handlers/recall.test.ts
+++ b/tests/handlers/recall.test.ts
@@ -76,6 +76,33 @@ describe('handleRecall', () => {
       expect(body.filters.after).toBe('2025-01-01T00:00:00Z');
       expect(body.filters.before).toBe('2025-06-01T00:00:00Z');
     });
+
+    it('passes pinned filter to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [{ id: '1', content: 'pinned', pinned: true }] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', { query: 'test', pinned: true });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters.pinned).toBe(true);
+    });
+
+    it('passes pinned=false filter to API', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', { query: 'test', pinned: false });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters.pinned).toBe(false);
+    });
+
+    it('omits pinned from filters when not specified', async () => {
+      const { ctx, api } = makeCtx({
+        'POST /v1/recall': { memories: [] },
+      });
+      await handleRecall(ctx, 'memoclaw_recall', { query: 'test' });
+      const body = api.makeRequest.mock.calls[0][2];
+      expect(body.filters).toBeUndefined();
+    });
   });
 
   describe('memoclaw_search', () => {


### PR DESCRIPTION
## What

Fixes a bug where `memoclaw_recall` silently drops the `pinned` filter, and adds missing autocomplete completions.

## Bug Fix
The `memoclaw_recall` tool schema includes `pinned` via `COMMON_FILTERS`, but the handler never destructured or forwarded it to the API. Agents trying to recall only pinned/unpinned memories got unfiltered results.

**Changes:**
- Added `pinned` to destructured args in `handleRecall`
- Added `if (pinned !== undefined) filters.pinned = pinned` to the filters object
- Added `pinned?: boolean` to `RecallArgs` type

## Enhancement
Added autocomplete completions for two arguments that were missing:
- `format` (memoclaw_export): `json`, `jsonl`
- `strategy` (memoclaw_merge): `keep_target`, `keep_source`, `combine`

## Tests
- 3 new tests for recall pinned filter (true, false, omitted)
- 4 new tests for format and strategy completions
- All 590 tests pass ✅
- Lint: 0 errors, Prettier: all clean

Fixes #175