### PR TITLE
feat: add metadata validation and configurable concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Optionally set a custom API URL:
 export MEMOCLAW_URL=https://api.memoclaw.com  # default
 export MEMOCLAW_TIMEOUT=30000                 # request timeout in ms (default: 30000)
 export MEMOCLAW_MAX_RETRIES=3                 # retries for transient failures (default: 3)
+export MEMOCLAW_CONCURRENCY=10                # concurrency for bulk operations (default: 10)
 export MEMOCLAW_HTTP_TOKEN=mysecrettoken       # bearer token for HTTP transport auth (optional)
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ export interface Config {
   timeout: number;
   /** Max retries for transient failures (default: 3) */
   maxRetries: number;
+  /** Concurrency limit for bulk operations (default: 10) */
+  concurrency: number;
 }
 
 /**
@@ -51,5 +53,8 @@ export function loadConfig(): Config {
   const parsedRetries = parseInt(process.env.MEMOCLAW_MAX_RETRIES || '', 10);
   const maxRetries = Number.isNaN(parsedRetries) ? 3 : parsedRetries;
 
-  return { privateKey, apiUrl, configSource, timeout, maxRetries };
+  const parsedConcurrency = parseInt(process.env.MEMOCLAW_CONCURRENCY || '', 10);
+  const concurrency = Number.isNaN(parsedConcurrency) || parsedConcurrency < 1 ? 10 : parsedConcurrency;
+
+  return { privateKey, apiUrl, configSource, timeout, maxRetries, concurrency };
 }

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -360,7 +360,7 @@ export async function handleAdmin(ctx: HandlerContext, name: string, args: any):
         if (toDelete.length === 0) break;
         const deleteResults = await withConcurrency(
           toDelete.map((m: any) => () => makeRequest('DELETE', `/v1/memories/${m.id}`)),
-          10,
+          config.concurrency,
           signal,
         );
         let pageSuccesses = 0;

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -9,7 +9,14 @@ import {
   userText,
   memoryResourceLink,
 } from '../format.js';
-import { validateIdentifier, validateId, validateTags, validateISODate, validatePaginationParam } from '../validate.js';
+import {
+  validateIdentifier,
+  validateId,
+  validateTags,
+  validateISODate,
+  validatePaginationParam,
+  validateMetadata,
+} from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type {
   StoreArgs,
@@ -92,7 +99,7 @@ async function bulkStoreWithFallback(
       await progress(storeProgress, memories.length);
       return result;
     }),
-    10,
+    ctx.config.concurrency,
     signal,
   );
   const succeeded = results.filter((r) => r?.status === 'fulfilled');
@@ -118,7 +125,7 @@ async function bulkStoreWithFallback(
 }
 
 export async function handleMemory(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest, progress, signal } = ctx;
+  const { makeRequest, config, progress, signal } = ctx;
 
   switch (name) {
     case 'memoclaw_store': {
@@ -146,6 +153,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       validateIdentifier(session_id, 'session_id');
       validateIdentifier(agent_id, 'agent_id');
       validateISODate(expires_at, 'expires_at');
+      validateMetadata(metadata);
       const body: any = { content };
       if (importance !== undefined) body.importance = importance;
       if (tags) body.tags = tags;
@@ -205,6 +213,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       validateIdentifier(agent_id, 'agent_id');
       validateISODate(after, 'after');
       validateISODate(before, 'before');
+      validateMetadata(metadata);
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (offset !== undefined) params.set('offset', String(offset));
@@ -300,7 +309,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
             await progress(deleteProgress, ids.length);
             return result;
           }),
-          10,
+          config.concurrency,
           signal,
         );
         succeeded = results.filter((r) => r?.status === 'fulfilled').length;
@@ -452,7 +461,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
               await progress(updateProgress, updates.length);
               return result;
             }),
-            10,
+            config.concurrency,
             signal,
           );
           const succeeded = results.filter((r) => r?.status === 'fulfilled');
@@ -492,6 +501,7 @@ export async function handleMemory(ctx: HandlerContext, name: string, args: any)
       const { namespace, tags, agent_id, memory_type, session_id, before, after, pinned, metadata } = args as CountArgs;
       validateISODate(after, 'after');
       validateISODate(before, 'before');
+      validateMetadata(metadata);
       const params = new URLSearchParams();
       if (namespace) params.set('namespace', namespace);
       if (tags && Array.isArray(tags) && tags.length > 0) params.set('tags', tags.join(','));

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -6,6 +6,7 @@ import {
   validateISODate,
   validatePaginationParam,
   validateSimilarity,
+  validateMetadata,
 } from '../validate.js';
 import type { HandlerContext, ToolResult } from './types.js';
 import type { RecallArgs, SearchArgs, ContextArgs, SuggestedArgs, CheckDuplicatesArgs } from '../types.js';
@@ -40,6 +41,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       validateIdentifier(agent_id, 'agent_id');
       validateISODate(after, 'after');
       validateISODate(before, 'before');
+      validateMetadata(metadata);
       const filters: Record<string, any> = {};
       if (tags) filters.tags = tags;
       if (memory_type) filters.memory_type = memory_type;
@@ -99,6 +101,7 @@ export async function handleRecall(ctx: HandlerContext, name: string, args: any)
       validateIdentifier(agent_id, 'agent_id');
       validateISODate(after, 'after');
       validateISODate(before, 'before');
+      validateMetadata(metadata);
       const params = new URLSearchParams();
       params.set('q', query);
       if (limit !== undefined) params.set('limit', String(limit));

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -5,7 +5,7 @@ import { throwIfCancelled } from './types.js';
 import type { CreateRelationArgs, ListRelationsArgs, DeleteRelationArgs, GraphArgs } from '../types.js';
 
 export async function handleRelations(ctx: HandlerContext, name: string, args: any): Promise<ToolResult | null> {
-  const { makeRequest, signal } = ctx;
+  const { makeRequest, config, signal } = ctx;
 
   switch (name) {
     case 'memoclaw_create_relation': {
@@ -94,7 +94,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
                 .then((mem) => ({ id: mid, data: mem.memory || mem }))
                 .catch(() => ({ id: mid, data: { id: mid, content: '(could not fetch)' } })),
           ),
-          10,
+          config.concurrency,
           signal,
         );
         for (const r of memResults) {
@@ -110,7 +110,7 @@ export async function handleRelations(ctx: HandlerContext, name: string, args: a
                   .then((relResult) => ({ id: mid, relations: relResult.relations || [] }))
                   .catch(() => ({ id: mid, relations: [] as any[] })),
             ),
-            10,
+            config.concurrency,
             signal,
           );
           for (const r of relResults) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -128,6 +128,33 @@ export function validateSimilarity(value: unknown, label = 'min_similarity'): nu
   return value;
 }
 
+/** Maximum number of top-level keys in a metadata object */
+const MAX_METADATA_KEYS = 50;
+
+/** Maximum serialised size for a metadata object (bytes) */
+const MAX_METADATA_SIZE = 8192;
+
+/**
+ * Validate a metadata parameter.
+ * Must be a plain object (not null, not an array, not a primitive).
+ * Returns undefined if value is falsy (optional params), throws on invalid.
+ */
+export function validateMetadata(value: unknown, label = 'metadata'): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length > MAX_METADATA_KEYS) {
+    throw new Error(`${label} has too many keys (${keys.length}). Maximum is ${MAX_METADATA_KEYS}.`);
+  }
+  const serialised = JSON.stringify(value);
+  if (serialised.length > MAX_METADATA_SIZE) {
+    throw new Error(`${label} is too large (${serialised.length} bytes). Maximum is ${MAX_METADATA_SIZE} bytes.`);
+  }
+  return value as Record<string, unknown>;
+}
+
 /**
  * Validate an ISO 8601 date string parameter (expires_at, after, before).
  * Returns undefined if value is falsy (optional params), throws on invalid.

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -12,6 +12,9 @@ const testConfig = {
   privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
   apiUrl: 'http://localhost:9999',
   configSource: 'test' as const,
+  timeout: 5000,
+  maxRetries: 0,
+  concurrency: 10,
 };
 
 function mockApi(routeResponses: Record<string, any>) {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -9,6 +9,7 @@ const mockConfig: Config = {
   configSource: 'test',
   timeout: 5000,
   maxRetries: 0,
+  concurrency: 10,
 };
 
 describe('Completions', () => {

--- a/tests/handlers-edge-cases.test.ts
+++ b/tests/handlers-edge-cases.test.ts
@@ -32,6 +32,7 @@ const testConfig: Config = {
   configSource: 'test',
   timeout: 5000,
   maxRetries: 0,
+  concurrency: 10,
 };
 
 describe('formatMemory', () => {

--- a/tests/handlers/helpers.ts
+++ b/tests/handlers/helpers.ts
@@ -53,4 +53,5 @@ export const testConfig: Config = {
   configSource: 'test',
   timeout: 5000,
   maxRetries: 0,
+  concurrency: 10,
 };

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -43,6 +43,7 @@ const mockConfig = {
   configSource: 'test',
   timeout: 5000,
   maxRetries: 0,
+  concurrency: 10,
 };
 
 describe('progress notifications', () => {

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -6,6 +6,7 @@ import {
   validateQuery,
   validateISODate,
   validatePaginationParam,
+  validateMetadata,
 } from '../src/validate.js';
 
 describe('validateIdentifier', () => {
@@ -197,5 +198,58 @@ describe('validateSimilarity', () => {
     expect(() => validateSimilarity(-0.1)).toThrow('must be between 0.0 and 1.0');
     expect(() => validateSimilarity(1.1)).toThrow('must be between 0.0 and 1.0');
     expect(() => validateSimilarity(5)).toThrow('must be between 0.0 and 1.0');
+  });
+});
+
+describe('validateMetadata', () => {
+  it('returns undefined for undefined/null', () => {
+    expect(validateMetadata(undefined)).toBeUndefined();
+    expect(validateMetadata(null)).toBeUndefined();
+  });
+
+  it('accepts a valid plain object', () => {
+    const obj = { key: 'value', nested: { a: 1 } };
+    expect(validateMetadata(obj)).toEqual(obj);
+  });
+
+  it('accepts an empty object', () => {
+    expect(validateMetadata({})).toEqual({});
+  });
+
+  it('rejects arrays', () => {
+    expect(() => validateMetadata([1, 2, 3])).toThrow('must be a plain object');
+  });
+
+  it('rejects strings', () => {
+    expect(() => validateMetadata('not an object')).toThrow('must be a plain object');
+  });
+
+  it('rejects numbers', () => {
+    expect(() => validateMetadata(42)).toThrow('must be a plain object');
+  });
+
+  it('rejects booleans', () => {
+    expect(() => validateMetadata(true)).toThrow('must be a plain object');
+  });
+
+  it('rejects objects with too many keys', () => {
+    const bigObj: Record<string, number> = {};
+    for (let i = 0; i < 51; i++) bigObj[`key${i}`] = i;
+    expect(() => validateMetadata(bigObj)).toThrow('too many keys');
+  });
+
+  it('accepts objects at the key limit', () => {
+    const obj: Record<string, number> = {};
+    for (let i = 0; i < 50; i++) obj[`key${i}`] = i;
+    expect(validateMetadata(obj)).toEqual(obj);
+  });
+
+  it('rejects objects that are too large when serialised', () => {
+    const bigObj = { data: 'x'.repeat(9000) };
+    expect(() => validateMetadata(bigObj)).toThrow('too large');
+  });
+
+  it('uses custom label in error messages', () => {
+    expect(() => validateMetadata('bad', 'custom_field')).toThrow('custom_field must be a plain object');
   });
 });


### PR DESCRIPTION
## Changes

### Metadata validation (Fixes #179)
- New `validateMetadata()` helper in `src/validate.ts`
  - Ensures metadata parameters are plain objects (rejects arrays, strings, numbers, booleans)
  - Limits to 50 top-level keys and 8KB serialised size
- Applied in handlers: `memoclaw_store`, `memoclaw_list`, `memoclaw_search`, `memoclaw_recall`, `memoclaw_count`
- 11 new tests covering all validation paths

### Configurable concurrency (Fixes #181)
- New `MEMOCLAW_CONCURRENCY` environment variable (default: 10)
- Added `concurrency` field to `Config` type
- Replaced all hardcoded `10` concurrency values in handlers with `config.concurrency`
- Affected handlers: bulk_store, bulk_delete, batch_update, delete_namespace, graph
- Documented in README

### Test results
607 tests passing (was 596, +11 new)