### PR TITLE
fix(security): resolve hono prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memoclaw-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memoclaw-mcp",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "type": "git",
     "url": "https://github.com/anajuliabit/memoclaw-mcp"
   },
-  "mcpName": "io.github.anajuliabit/memoclaw-mcp"
+  "mcpName": "io.github.anajuliabit/memoclaw-mcp",
+  "overrides": {
+    "hono": "^4.12.7"
+  }
 }


### PR DESCRIPTION
## Summary

Fixes moderate severity prototype pollution vulnerability in `hono` (GHSA-v8w9-8mx6-g223).

### Problem
`hono@4.12.5` (transitive dependency via `@modelcontextprotocol/sdk`) is vulnerable to prototype pollution through `__proto__` key allowed in `parseBody({ dot: true })`.

### Fix
Added npm override to pin `hono >= 4.12.7` which includes the fix. The MCP SDK already allows `^4.11.4` so this is a compatible upgrade.

### Verification
- `npm audit` reports 0 vulnerabilities after fix
- All 596 tests pass