### PR TITLE
fix: add missing validation for bulk operations (bulk_store, import, batch_update)

### DIFF
--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -355,7 +355,14 @@ export async function handleMemory(
         }
         validateContentLength(m.content, `Memory at index ${i}`);
         validateImportance(m.importance, `Memory at index ${i} importance`);
+        validateTags(m.tags, `Memory at index ${i} tags`);
+        validateMetadata(m.metadata, `Memory at index ${i} metadata`);
+        validateIdentifier(m.namespace, `Memory at index ${i} namespace`);
+        validateIdentifier(m.memory_type, `Memory at index ${i} memory_type`);
+        validateISODate(m.expires_at, `Memory at index ${i} expires_at`);
       }
+      if (session_id) validateIdentifier(session_id, 'session_id');
+      if (agent_id) validateIdentifier(agent_id, 'agent_id');
       return bulkStoreWithFallback(
         ctx,
         memories as unknown as Array<Record<string, unknown>>,
@@ -378,7 +385,14 @@ export async function handleMemory(
         }
         validateContentLength(m.content, `Memory at index ${i}`);
         validateImportance(m.importance, `Memory at index ${i} importance`);
+        validateTags(m.tags, `Memory at index ${i} tags`);
+        validateMetadata(m.metadata, `Memory at index ${i} metadata`);
+        validateIdentifier(m.namespace, `Memory at index ${i} namespace`);
+        validateIdentifier(m.memory_type, `Memory at index ${i} memory_type`);
+        validateISODate(m.expires_at, `Memory at index ${i} expires_at`);
       }
+      if (session_id) validateIdentifier(session_id, 'session_id');
+      if (agent_id) validateIdentifier(agent_id, 'agent_id');
       return bulkStoreWithFallback(
         ctx,
         memories as unknown as Array<Record<string, unknown>>,
@@ -428,6 +442,10 @@ export async function handleMemory(
         if (!u.id) throw new Error(`Update at index ${i} is missing "id"`);
         validateImportance(u.importance, `Update at index ${i} importance`);
         validateTags(u.tags, `Update at index ${i} tags`);
+        validateMetadata(u.metadata, `Update at index ${i} metadata`);
+        validateIdentifier(u.namespace, `Update at index ${i} namespace`);
+        validateIdentifier(u.memory_type, `Update at index ${i} memory_type`);
+        validateISODate(u.expires_at, `Update at index ${i} expires_at`);
       }
       try {
         const result = await makeRequest('POST', '/v1/memories/batch-update', { updates });

--- a/tests/handlers/memory.test.ts
+++ b/tests/handlers/memory.test.ts
@@ -347,6 +347,52 @@ describe('handleMemory', () => {
       expect(body.memories[0].content).toBe('ok');
       expect(body.memories[0].extra_bad_field).toBeUndefined();
     });
+
+    it('validates tags in bulk store entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_bulk_store', {
+          memories: [{ content: 'ok', tags: [123 as any] }],
+        }),
+      ).rejects.toThrow('non-empty string');
+    });
+
+    it('validates metadata in bulk store entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_bulk_store', {
+          memories: [{ content: 'ok', metadata: 'not-an-object' as any }],
+        }),
+      ).rejects.toThrow('plain object');
+    });
+
+    it('validates namespace identifier in bulk store entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_bulk_store', {
+          memories: [{ content: 'ok', namespace: 'bad namespace!' }],
+        }),
+      ).rejects.toThrow('invalid characters');
+    });
+
+    it('validates expires_at date in bulk store entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_bulk_store', {
+          memories: [{ content: 'ok', expires_at: 'not-a-date' }],
+        }),
+      ).rejects.toThrow('not a valid date');
+    });
+
+    it('validates session_id and agent_id identifiers', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_bulk_store', {
+          memories: [{ content: 'ok' }],
+          session_id: 'bad id!',
+        }),
+      ).rejects.toThrow('invalid characters');
+    });
   });
 
   // ── import ───────────────────────────────────────────────────────────────
@@ -385,6 +431,33 @@ describe('handleMemory', () => {
       const callBody = api.makeRequest.mock.calls[0][2];
       expect(callBody.memories[0].metadata).toEqual({ source: 'migration' });
       expect(callBody.memories[0].expires_at).toBe('2026-12-31T23:59:59Z');
+    });
+
+    it('validates tags in import entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_import', {
+          memories: [{ content: 'ok', tags: [123 as any] }],
+        }),
+      ).rejects.toThrow('non-empty string');
+    });
+
+    it('validates metadata in import entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_import', {
+          memories: [{ content: 'ok', metadata: [1, 2, 3] as any }],
+        }),
+      ).rejects.toThrow('plain object');
+    });
+
+    it('validates namespace identifier in import entries', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_import', {
+          memories: [{ content: 'ok', namespace: 'has spaces!' }],
+        }),
+      ).rejects.toThrow('invalid characters');
     });
   });
 
@@ -482,6 +555,33 @@ describe('handleMemory', () => {
           updates: [{ id: '1', tags: ['valid', ''] }],
         }),
       ).rejects.toThrow('tags[1] must be a non-empty string');
+    });
+
+    it('validates metadata in individual updates', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_batch_update', {
+          updates: [{ id: '1', metadata: 'not-object' as any }],
+        }),
+      ).rejects.toThrow('plain object');
+    });
+
+    it('validates namespace identifier in individual updates', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_batch_update', {
+          updates: [{ id: '1', namespace: 'bad namespace!' }],
+        }),
+      ).rejects.toThrow('invalid characters');
+    });
+
+    it('validates expires_at in individual updates', async () => {
+      const { ctx } = makeCtx();
+      await expect(
+        handleMemory(ctx, 'memoclaw_batch_update', {
+          updates: [{ id: '1', expires_at: 'not-a-date' }],
+        }),
+      ).rejects.toThrow('not a valid date');
     });
   });
 


### PR DESCRIPTION
## Problem (Fixes #188)

Bulk operations (`memoclaw_bulk_store`, `memoclaw_import`, `memoclaw_batch_update`) were missing several validators that are applied in their single-item counterparts. Invalid data (e.g. malformed metadata, tags with invalid types, bad namespace identifiers, invalid dates) could bypass client-side validation and result in confusing API errors.

## Changes

### `src/handlers/memory.ts`
Added the following validation to bulk operation per-item loops:
- `validateTags` — ensures tag arrays contain valid strings
- `validateMetadata` — ensures metadata is a plain object
- `validateIdentifier` — validates namespace, memory_type, session_id, agent_id format
- `validateISODate` — validates expires_at is a valid ISO date string

Also added top-level `session_id` and `agent_id` validation for `bulk_store` and `import`.

### `tests/handlers/memory.test.ts`
Added 11 new test cases covering:
- Tags validation in bulk_store, import entries
- Metadata validation in bulk_store, import, batch_update entries
- Namespace identifier validation across all three operations
- expires_at date validation in bulk_store, batch_update
- session_id/agent_id validation in bulk_store

### Test results
618 tests passing (607 existing + 11 new), clean TypeScript compile.