### PR TITLE
chore: drop Node.js 18 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: namespace-profile-default
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Changes

- Remove Node 18 from CI matrix (EOL since April 2025)
- Update `engines.node` from `>=18` to `>=20` in package.json

## Why

Node.js 18 reached End-of-Life on April 30, 2025. It no longer receives security patches. The Node 18 CI job was the slowest in the matrix. Dropping it aligns with ecosystem best practices.

Fixes #187