### PR TITLE
chore: upgrade MCP SDK to ^1.27.1 and bump tsconfig target to ES2023

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@x402/core": "^2.3.0",
         "@x402/evm": "^2.3.0",
         "viem": "^2.0.0"
@@ -28,7 +28,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@x402/core": "^2.3.0",
     "@x402/evm": "^2.3.0",
     "viem": "^2.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",


### PR DESCRIPTION
## Changes

- **Update `@modelcontextprotocol/sdk`** from `^1.0.0` to `^1.27.1` — closes a significant version gap, bringing bug fixes, new protocol features, and better client compatibility
- **Bump tsconfig target** from `ES2022` to `ES2023` — now that Node 18 is dropped (#187), we can target ES2023 natively supported by Node 20+

## Verification

- Build: ✅ clean
- Tests: ✅ 618/618 passing
- Lint: ✅ 0 errors (199 pre-existing `no-explicit-any` warnings in tests)

Fixes #191
Fixes #192